### PR TITLE
Document and enforce independent bot SSH identities

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,23 @@ Your public-key fingerprint becomes your identity. Connect with a key to keep yo
 
 > New to SSH? The command above is all you need on macOS, Linux, Windows Terminal, Termux, or another OpenSSH-compatible client.
 
+### Bot players and independent identities
+
+Bots use the same matchmaking and ratings as terminal players. Because identity is the SSH public-key fingerprint, reuse of your normal SSH key also reuses your handle, ELO, and match history. Give each bot a dedicated key when those records should remain independent:
+
+```console
+ssh-keygen -t ed25519 -f ~/.ssh/sshfighter-mybot -C sshfighter-mybot
+ssh -i ~/.ssh/sshfighter-mybot -o IdentitiesOnly=yes MYBOT@<host>
+```
+
+During that one interactive connection, choose the bot's handle. Then launch the JSON-lines example with the same key:
+
+```console
+node examples/bot.mjs --user MYBOT --host <host> --char BYU --identity ~/.ssh/sshfighter-mybot
+```
+
+`--identity` also enables OpenSSH's `IdentitiesOnly=yes`, preventing fallback to a personal key. SSH bot play needs no API token. Mint one with `ssh -i <key> -o IdentitiesOnly=yes MYBOT@<host> token` only when using the REST API or optional direct TCP transport. See [`examples/bot.mjs`](examples/bot.mjs) for the protocol and a small example controller.
+
 ## Controls
 
 | Action | Key |

--- a/examples/bot.mjs
+++ b/examples/bot.mjs
@@ -3,20 +3,26 @@
 // SSH Street Fighter — example bot
 // ----------------------------------------------------------------------------
 // A bot is just an ordinary player that reaches the game over an API instead of
-// a terminal. Identity is anchored to your SSH key: you register over SSH, then
-// you play over SSH. You queue for quick matches against humans and bots alike.
+// a terminal. Identity is anchored to your SSH key, so give each bot its own key
+// if its handle, rating, and match history should be independent. Bots queue for
+// quick matches against humans and bots alike.
 //
-//   1. Register (one time), which mints an API key bound to your SSH key:
-//        ssh <yourbot>@sshfighter.com token
+//   1. Create a dedicated key and claim its handle in one interactive login:
+//        ssh-keygen -t ed25519 -f ~/.ssh/sshfighter-mybot -C sshfighter-mybot
+//        ssh -i ~/.ssh/sshfighter-mybot -o IdentitiesOnly=yes MYBOT@sshfighter.com
 //
 //   2. Play — the recommended path streams the match over SSH itself:
-//        node examples/bot.mjs --user <yourbot> --host sshfighter.com --char BYU
+//        node examples/bot.mjs --user MYBOT --host sshfighter.com --char BYU \
+//          --identity ~/.ssh/sshfighter-mybot
 //
-//      That spawns `ssh <yourbot>@sshfighter.com play` and speaks newline-
-//      delimited JSON over the channel. Your SSH key authenticates you, so no
-//      API key is needed on this path.
+//      That spawns `ssh -i <key> -o IdentitiesOnly=yes MYBOT@sshfighter.com play`
+//      and speaks newline-delimited JSON over the channel. No API key is needed
+//      on this path.
 //
-//   3. Direct TCP (if the bot port is reachable) authenticates with the key:
+//   3. Optional: mint an API key for REST or direct TCP access:
+//        ssh -i ~/.ssh/sshfighter-mybot -o IdentitiesOnly=yes MYBOT@sshfighter.com token
+//
+//      Direct TCP (if the bot port is reachable) authenticates with that token:
 //        node examples/bot.mjs --tcp <host>:8091 --key rk_xxx --char BYU
 //
 // Protocol (newline-delimited JSON both ways):
@@ -34,10 +40,38 @@ import net from 'node:net';
 import readline from 'node:readline';
 
 // ---- args ----
-const args = Object.fromEntries(
-  process.argv.slice(2).join(' ').split(/\s+--/).filter(Boolean)
-    .map((s) => s.replace(/^--/, '')).map((s) => { const i = s.indexOf(' '); return i < 0 ? [s, true] : [s.slice(0, i), s.slice(i + 1).trim()]; }),
-);
+const args = {};
+for (let i = 2; i < process.argv.length; i++) {
+  const arg = process.argv[i];
+  if (!arg.startsWith('--')) continue;
+  const name = arg.slice(2);
+  const next = process.argv[i + 1];
+  args[name] = next && !next.startsWith('--') ? process.argv[++i] : true;
+}
+
+if (args.help) {
+  console.log(`Usage:
+  node examples/bot.mjs [--user NAME] [--host HOST] [--char FIGHTER] [--identity KEY]
+  node examples/bot.mjs --tcp HOST:PORT --key rk_xxx [--char FIGHTER]
+
+Options:
+  --identity KEY  Dedicated SSH private key. Also enables IdentitiesOnly=yes.
+  --user NAME     SSH username (default: BOT).
+  --host HOST     SSH host (default: sshfighter.com).
+  --char FIGHTER  Fighter to queue as (default: BYU).
+  --tcp HOST:PORT Use direct TCP instead of the recommended SSH transport.
+  --key TOKEN     API key required by direct TCP.
+  --help          Show this help.`);
+  process.exit(0);
+}
+
+for (const name of ['identity', 'user', 'host', 'char', 'tcp', 'key']) {
+  if (args[name] === true) {
+    console.error(`--${name} requires a value`);
+    process.exit(2);
+  }
+}
+
 const CHAR = args.char || 'BYU';
 const HOST = args.host || 'sshfighter.com';
 const USER = args.user || 'BOT';
@@ -56,8 +90,12 @@ if (args.tcp) {
   preAuthed = false;   // must send {t:'hello',key}
   if (!args.key) { console.error('--tcp requires --key rk_... (mint via: ssh host token)'); process.exit(1); }
 } else {
-  // Spawn ssh and run the `play` command; key auth = registration.
-  const ssh = spawn('ssh', ['-T', `${USER}@${HOST}`, 'play'], { stdio: ['pipe', 'pipe', 'inherit'] });
+  // Spawn ssh and run the `play` command. A dedicated identity keeps this bot's
+  // handle, rating, and match history separate from the operator's account.
+  const sshArgs = ['-T'];
+  if (args.identity) sshArgs.push('-i', String(args.identity), '-o', 'IdentitiesOnly=yes');
+  sshArgs.push(`${USER}@${HOST}`, 'play');
+  const ssh = spawn('ssh', sshArgs, { stdio: ['pipe', 'pipe', 'inherit'] });
   ssh.on('exit', (code) => { console.log(`ssh exited (${code})`); process.exit(code || 0); });
   toGame = (obj) => ssh.stdin.write(JSON.stringify(obj) + '\n');
   lineSource = readline.createInterface({ input: ssh.stdout });


### PR DESCRIPTION
## What changed

- document the one-time dedicated-key onboarding flow for independently rated bot players
- add `--identity <key-path>` to the example controller and force `IdentitiesOnly=yes`
- preserve quoted argument values, including Windows paths containing spaces
- add CLI help and missing-value errors
- clarify that SSH play needs no API token; tokens are only needed for REST or direct TCP

## Why

The server already keys player identity, handle, ELO, and match history to the SSH public-key fingerprint. The example previously let OpenSSH choose any default key, so a bot could silently play under its operator's existing identity. It also described token minting as registration even though the recommended SSH play path does not require a token.

This keeps identity separation explicit without changing server authentication or the bot protocol.

## Validation

- `node --check examples/bot.mjs`
- `node examples/bot.mjs --help`
- missing `--identity` value exits with code 2 and an actionable error
- `pnpm typecheck`
- engine, asset, database, input, render, and telemetry tests pass
- `pnpm exec next build --webpack` passes on Windows

Known unrelated repository/environment failures encountered while running the contribution checklist:

- `pnpm test` reaches the existing responsive HUD assertions, which fail at all tested terminal sizes
- `pnpm test:e2e` stops in the navigation test before exercising this standalone example
- the default Turbopack web build cannot create a `better-sqlite3` symlink without Windows developer-mode privilege; the webpack build succeeds
