### PR TITLE
Fix responsive HUD coverage for pixel surfaces

### DIFF
--- a/src/hud-test.ts
+++ b/src/hud-test.ts
@@ -1,10 +1,45 @@
-// The fight HUD must remain textual and complete as terminal font zoom changes
-// the available cell grid. Exercise every responsive tier down to our 24x12
-// minimum and ensure both fighters, timer, health, announcement and exits exist.
+// The fight HUD must remain complete as terminal font zoom changes the available
+// pixel-surface grid. Record the semantic draw calls while delegating to the real
+// pixel renderer, then verify every supported responsive tier keeps the fighters,
+// timer, health, announcement, and essential controls.
 import { Frame } from './render/frame.js';
 import { composeScene } from './game/scene.js';
-import { drawFightHud } from './screens/fight-hud.js';
+import { drawFightHudSurface } from './screens/fight-hud.js';
 import { makeFighter, makeMatch } from './game/engine.js';
+import { makeSurface, minTerminal, pixelReady, type PanelOpts, type Rect, type Surface, type TextOpts } from './ui/surface.js';
+import { THEME } from './ui/theme.js';
+import type { RGB } from './render/pixel.js';
+
+class HudProbe implements Surface {
+  texts: string[] = [];
+  headings: string[] = [];
+  fills: RGB[] = [];
+
+  constructor(private inner: Surface) {}
+  get cols(): number { return this.inner.cols; }
+  get rows(): number { return this.inner.rows; }
+  get kind(): 'cell' | 'pixel' { return this.inner.kind; }
+  gradient(top: RGB, bot: RGB): void { this.inner.gradient(top, bot); }
+  fill(x: number, y: number, w: number, h: number, color: RGB): void {
+    this.fills.push(color);
+    this.inner.fill(x, y, w, h, color);
+  }
+  text(x: number, y: number, str: string, o?: TextOpts): void {
+    this.texts.push(str);
+    this.inner.text(x, y, str, o);
+  }
+  panel(x: number, y: number, w: number, h: number, o?: PanelOpts): Rect { return this.inner.panel(x, y, w, h, o); }
+  heading(y: number, str: string, color: RGB, scale?: number): void {
+    this.headings.push(str);
+    this.inner.heading(y, str, color, scale);
+  }
+  headingHeight(scale?: number): number { return this.inner.headingHeight(scale); }
+  width(str: string): number { return this.inner.width(str); }
+  unitX(subPx: number): number { return this.inner.unitX(subPx); }
+  unitY(subPy: number): number { return this.inner.unitY(subPy); }
+}
+
+const sameColor = (a: RGB, b: RGB): boolean => a.r === b.r && a.g === b.g && a.b === b.b;
 
 const a = makeFighter('a', 'BYU', 'a');
 const b = makeFighter('b', 'MEN', 'b');
@@ -13,19 +48,21 @@ match.phase = 'fight'; match.message = 'ROUND 1'; match.roundTime = 47;
 a.hp = 72; b.hp = 38; a.wins = 1;
 
 let failed = false;
-for (const [cols, rows] of [[24, 12], [34, 14], [44, 16], [68, 20], [96, 28], [160, 48]] as const) {
+const minimum = minTerminal();
+const sizes = [[minimum.cols, minimum.rows], [160, 55], [240, 80], [320, 120]] as const;
+for (const [cols, rows] of sizes) {
   const frame = new Frame(cols, rows, 'octant');
   frame.usePixel(composeScene(match, cols * 2, rows * 4));
-  drawFightHud(frame, match, false);
-  const cells = frame.toCells();
-  const lines = Array.from({ length: rows }, (_, y) => cells.slice(y * cols, (y + 1) * cols).map((cell) => cell.ch).join(''));
-  const top = lines[0] ?? '', bars = lines[1] ?? '', all = lines.join('\n'), footer = lines[rows - 1] ?? '';
+  const probe = new HudProbe(makeSurface(frame));
+  drawFightHudSurface(probe, match, false);
+  const text = probe.texts.join(' ');
   const checks = {
-    fighters: top.includes('BYU') && top.includes('MEN'),
-    timer: top.includes('47'),
-    health: bars.includes('█') && bars.includes('░'),
-    announcement: all.includes('ROUND 1'),
-    essential_controls: footer.includes('?') && footer.includes('Q'),
+    supported: pixelReady(cols, rows) && probe.kind === 'pixel',
+    fighters: text.includes('BYU') && text.includes('MEN'),
+    timer: text.includes('47'),
+    health: probe.fills.some((c) => sameColor(c, THEME.hpFull)) && probe.fills.some((c) => sameColor(c, THEME.accent)),
+    announcement: probe.headings.includes('ROUND 1'),
+    essential_controls: probe.texts.includes('?') && probe.texts.includes('Q'),
   };
   const ok = Object.values(checks).every(Boolean);
   if (!ok) failed = true;

--- a/src/screens/fight-hud.ts
+++ b/src/screens/fight-hud.ts
@@ -4,7 +4,7 @@
 // balloons over the fighters.
 import type { Frame } from '../render/frame.js';
 import type { Match } from '../game/types.js';
-import { makeSurface } from '../ui/surface.js';
+import { makeSurface, type Surface } from '../ui/surface.js';
 import { healthBar, banner, hints, centerText } from '../ui/widgets.js';
 import { THEME } from '../ui/theme.js';
 import { rgb } from '../render/pixel.js';
@@ -26,8 +26,9 @@ function controls(cols: number, practice: boolean, bindings: KeyBindings): [stri
   return [[punch, 'HIT'], [kick, 'KICK'], ['?', 'MOVES'], ['Q', quit]];
 }
 
-export function drawFightHud(f: Frame, m: Match, practice: boolean, bindings: KeyBindings = DEFAULT_KEY_BINDINGS, showControls = true): void {
-  const ui = makeSurface(f);
+/** Draw the HUD through an existing surface. Exported separately so tests can
+ * observe the semantic layout while delegating to the real pixel renderer. */
+export function drawFightHudSurface(ui: Surface, m: Match, practice: boolean, bindings: KeyBindings = DEFAULT_KEY_BINDINGS, showControls = true): void {
   const cols = ui.cols;
   const margin = 2;
   const gap = cols >= 40 ? 6 : 2;
@@ -65,4 +66,8 @@ export function drawFightHud(f: Frame, m: Match, practice: boolean, bindings: Ke
 
   // --- controls (suppressed when the host screen draws its own footer, e.g. calibrate) ---
   if (showControls) hints(ui, ui.rows - 1, controls(cols, practice, bindings));
+}
+
+export function drawFightHud(f: Frame, m: Match, practice: boolean, bindings: KeyBindings = DEFAULT_KEY_BINDINGS, showControls = true): void {
+  drawFightHudSurface(makeSurface(f), m, practice, bindings, showControls);
 }


### PR DESCRIPTION
## What changed

- extract the existing HUD layout into `drawFightHudSurface`, while keeping `drawFightHud` as the unchanged production entry point
- replace stale terminal-glyph assertions with a semantic probe that delegates to the real pixel surface
- exercise the advertised 144x50 minimum plus larger responsive terminal sizes
- verify fighter names, timer, both health states, round announcement, and help/quit controls

## Root cause

The HUD moved from literal terminal text cells to the shared constant-size pixel surface, but `hud-test.ts` still searched the final block-glyph stream for strings and health-bar characters. It also exercised 24x12 even though the current UI intentionally gates gameplay below 144x50. The HUD rendered correctly; the test observed an obsolete representation and unsupported sizes.

The probe records semantic Surface calls while forwarding every call to the real pixel renderer, so production behavior remains covered without depending on rasterized glyph encoding.

## Validation

- `pnpm typecheck`
- `pnpm test` — full game suite passes
- responsive HUD passes at 144x50, 160x55, 240x80, and 320x120
- rebased onto current `main` after independent bot identity PR #6 merged; typecheck and HUD test still pass
- gallery CI passes

The game CI job now passes `pnpm test`, including the formerly blocking HUD test, and reaches the separate `Real SSH end-to-end flows` step. That step still fails in the unchanged `navigation-test.ts`, which assumes the pre-calibration, literal-text UI and a now-unsupported 112x36 PTY. That independent stale test is intentionally not mixed into this focused HUD PR.
