### PR TITLE
feat: add velocity-weighted Weight of Evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The terminal has no diagonal key events, so specials use compact four-direction 
 | **KIRA** | `→ ↓ → + W` Zero Ascent · `↓ → + W` Phase Needle · `↓ ← + E` Rift Counter |
 | **MAKO** | `↓ → + W` Moon Tide · `↓ → + E` Ginga Rush · `↓ ← + E` Axé Wheel |
 | **OMEGA** | `↓ → + W` Final Testimony · `← → + E` Null Step · `↓ ← + W` Entropy Well |
-| **CODEX** | `↓ ↑ + W` Context Ascent · `← → + E` Branchwalk · `↓ → + E` Merge Comet |
+| **CODEX** | `↓ ↑ + W` Context Ascent · `← → + E` Branchwalk · `↓ → + E` Weight of Evidence (also during Context descent) |
 
 </details>
 

--- a/src/engine-test.ts
+++ b/src/engine-test.ts
@@ -1,5 +1,5 @@
 // Headless mechanics test for the fluid engine.
-import { makeFighter, makeMatch, stepMatch, ATTACKS, STAGE_RIGHT, specialMoveStats } from './game/engine.js';
+import { makeFighter, makeMatch, stepMatch, ATTACKS, STAGE_RIGHT, MERGE_COMET, specialMoveStats } from './game/engine.js';
 import { emptyInputs, type Inputs } from './game/types.js';
 import { ROSTER } from './game/roster.js';
 import { specialMoveMotionCode, specialMovesFor } from './game/moves.js';
@@ -176,11 +176,13 @@ for (let k = 0; k < 29; k++) stepMatch(m, idle(), idle());
 check('ENTROPY WELL pulls inward and pulses repeatedly', m.b.x - m.a.x < entropyGap && hp - m.b.hp >= 8, `gap=${entropyGap.toFixed(1)}→${(m.b.x - m.a.x).toFixed(1)} dmg=${hp - m.b.hp}`);
 
 // 18) CODEX uses three unique, lower-damage aerial commitments. Context Ascent
-// clears Omega's beam vertically without introducing immunity or reflection.
+// clears Omega's beam vertically without introducing immunity or reflection,
+// then Weight of Evidence may revise only the descending half into a capped dive.
 const codexMoves = specialMovesFor('CODEX');
 const nonCodexAttacks = new Set(ROSTER.filter((character) => character.name !== 'CODEX').flatMap((character) => specialMovesFor(character.name).map((move) => move.attack)));
 check('CODEX specials use three unique attack kinds', new Set(codexMoves.map((move) => move.attack)).size === 3 && codexMoves.every((move) => !nonCodexAttacks.has(move.attack)), codexMoves.map((move) => move.attack).join(','));
 check('CODEX specials stay below Final Testimony damage', codexMoves.every((move) => specialMoveStats(move.attack).maxDamage < specialMoveStats('testimony').maxDamage));
+check('CODEX names its gravity dive WEIGHT OF EVIDENCE', codexMoves.find((move) => move.attack === 'mergecomet')?.name === 'WEIGHT OF EVIDENCE');
 
 m = fresh('CODEX', 'OMEGA'); m.a.x = 58; m.b.x = 182; hp = m.a.hp;
 {
@@ -199,7 +201,20 @@ check('BRANCHWALK commits forward through one aerial lane', m.a.x > 95 && m.a.y 
 m = fresh('CODEX'); m.a.x = 76; m.b.x = 112; hp = m.b.hp;
 { const i = idle(); i.motion = 'DR'; i.kick = true; stepMatch(m, i, idle()); }
 for (let k = 0; k < 22; k++) stepMatch(m, idle(), idle());
-check('MERGE COMET telegraphs a rise before the damaging dive', m.b.hp < hp && m.a.y < 30, `y=${m.a.y.toFixed(1)} dmg=${hp - m.b.hp}`);
+check('WEIGHT OF EVIDENCE telegraphs a rise before the damaging dive', m.b.hp < hp && m.a.y < 30, `y=${m.a.y.toFixed(1)} dmg=${hp - m.b.hp}`);
+
+m = fresh('CODEX'); m.a.x = 76; m.b.x = 114; hp = m.b.hp;
+{ const i = idle(); i.motion = 'DU'; i.punch = true; stepMatch(m, i, idle()); }
+for (let k = 0; k < 5; k++) stepMatch(m, idle(), idle());
+{ const i = idle(); i.motion = 'DR'; i.kick = true; stepMatch(m, i, idle()); }
+check('WEIGHT OF EVIDENCE cannot cancel the Context ascent', m.a.attack === 'context' && m.a.vy > 0, `attack=${m.a.attack} vy=${m.a.vy.toFixed(1)}`);
+for (let k = 0; k < 30 && m.a.vy >= 0; k++) stepMatch(m, idle(), idle());
+const descentY = m.a.y;
+{ const i = idle(); i.motion = 'DR'; i.kick = true; stepMatch(m, i, idle()); }
+const revisedOnDescent = m.a.attack === 'mergecomet' && m.a.attackFrame === MERGE_COMET.startup - 1 && m.a.vy < 0;
+for (let k = 0; k < 12; k++) stepMatch(m, idle(), idle());
+check('WEIGHT OF EVIDENCE cancels Context only on descent', revisedOnDescent && m.b.hp < hp, `startY=${descentY.toFixed(1)} attack=${m.a.attack} dmg=${hp - m.b.hp}`);
+check('WEIGHT OF EVIDENCE compounds to its capped damage on a long fall', hp - m.b.hp === specialMoveStats('mergecomet').maxDamage, `dmg=${hp - m.b.hp}`);
 
 // 19) Every projectile fighter's appearance follows its move definition, not a character-name conditional.
 for (const character of ROSTER) {

--- a/src/game/engine.ts
+++ b/src/game/engine.ts
@@ -71,7 +71,7 @@ export const NULL_STEP = { startup: 6, shift: 6, active: 4, recovery: 17, total:
 export const ENTROPY = { startup: 8, active: 18, recovery: 12, total: 38, dmg: 4, range: 96, kb: 0.8, chip: 1, vert: 56, hitEvery: 6, wellOffset: 42, pull: 1.2 }; // pull + three pulses
 export const CONTEXT = { startup: 5, active: 9, recovery: 30, total: 44, dmg: 9, range: 27, kb: 2.4, chip: 2, vert: 44, jumpV: 10.8, vx: 0.8 }; // ultra-high evasive rise
 export const BRANCHWALK = { startup: 7, active: 8, recovery: 18, total: 33, dmg: 10, range: 29, kb: 2.8, chip: 2, vert: 48, jumpV: 5.4, vx: 3.7 }; // committing forward glide
-export const MERGE_COMET = { startup: 10, active: 7, recovery: 15, total: 32, dmg: 12, range: 32, kb: 3.8, chip: 3, vert: 54, jumpV: 7.2, riseVx: 0.8, diveV: -6.4, diveVx: 3.5 }; // telegraphed diagonal dive
+export const MERGE_COMET = { startup: 10, active: 7, recovery: 15, total: 32, dmg: 9, maxDmg: 12, range: 32, maxRange: 38, kb: 3.2, maxKb: 4.4, chip: 2, maxChip: 3, vert: 54, jumpV: 7.2, riseVx: 0.8, diveV: -6.4, fullWeightV: -9.5, diveVx: 3.5 }; // Weight of Evidence: velocity-compounding gravity dive
 const FIRE_SPEED = 3.4, FIRE_R = 11, FIGHTER_WORLD_H = 56, FIRE_DMG = 12, FIRE_CHIP = 3;
 const EARLY_UP_GRACE_Y = 26;
 
@@ -99,13 +99,20 @@ export function specialMoveStats(attack: SpecialAttack): SpecialMoveStats {
   if (attack === 'nullstep') return { startup: NULL_STEP.startup, active: NULL_STEP.active, recovery: NULL_STEP.recovery, damagePerHit: NULL_STEP.dmg, maxHits: 1, maxDamage: NULL_STEP.dmg, chipPerHit: NULL_STEP.chip, range: NULL_STEP.range, impact: 'Phase-through cross-up' };
   if (attack === 'context') return { startup: CONTEXT.startup, active: CONTEXT.active, recovery: CONTEXT.recovery, damagePerHit: CONTEXT.dmg, maxHits: 1, maxDamage: CONTEXT.dmg, chipPerHit: CONTEXT.chip, range: CONTEXT.range, impact: 'Ultra-high evasive ascent' };
   if (attack === 'branchwalk') return { startup: BRANCHWALK.startup, active: BRANCHWALK.active, recovery: BRANCHWALK.recovery, damagePerHit: BRANCHWALK.dmg, maxHits: 1, maxDamage: BRANCHWALK.dmg, chipPerHit: BRANCHWALK.chip, range: BRANCHWALK.range, impact: 'Committing aerial glide' };
-  if (attack === 'mergecomet') return { startup: MERGE_COMET.startup, active: MERGE_COMET.active, recovery: MERGE_COMET.recovery, damagePerHit: MERGE_COMET.dmg, maxHits: 1, maxDamage: MERGE_COMET.dmg, chipPerHit: MERGE_COMET.chip, range: MERGE_COMET.range, impact: 'Telegraphed diagonal dive' };
+  if (attack === 'mergecomet') return { startup: MERGE_COMET.startup, active: MERGE_COMET.active, recovery: MERGE_COMET.recovery, damagePerHit: MERGE_COMET.dmg, maxHits: 1, maxDamage: MERGE_COMET.maxDmg, chipPerHit: MERGE_COMET.maxChip, range: MERGE_COMET.maxRange, impact: 'Velocity-weighted gravity dive' };
   const hits = Math.ceil(ENTROPY.active / ENTROPY.hitEvery);
   return { startup: ENTROPY.startup, active: ENTROPY.active, recovery: ENTROPY.recovery, damagePerHit: ENTROPY.dmg, maxHits: hits, maxDamage: ENTROPY.dmg * hits, chipPerHit: ENTROPY.chip, range: ENTROPY.range, impact: 'Pulling gravity field' };
 }
 
 interface MeleeSpec { dmg: number; range: number; kb: number; chip: number; vert: number; omni?: boolean }
-function meleeSpec(k: AttackKind): MeleeSpec | null {
+function weightOfEvidenceFactor(f: Fighter): number {
+  if (f.attack !== 'mergecomet') return 0;
+  const gainedFallSpeed = Math.max(0, -f.vy - Math.abs(MERGE_COMET.diveV));
+  const fullWeightGain = Math.abs(MERGE_COMET.fullWeightV) - Math.abs(MERGE_COMET.diveV);
+  return Math.min(1, gainedFallSpeed / fullWeightGain);
+}
+function meleeSpec(f: Fighter): MeleeSpec | null {
+  const k = f.attack;
   if (k === 'punch' || k === 'kick') { const a = ATTACKS[k]; return { dmg: a.dmg, range: a.range, kb: a.kb, chip: a.chip, vert: 34 }; }
   if (k === 'shoryuken') return { dmg: SHORYU.dmg, range: SHORYU.range, kb: SHORYU.kb, chip: SHORYU.chip, vert: SHORYU.vert };
   if (k === 'hurricane') return { dmg: HURRI.dmg, range: HURRI.range, kb: HURRI.kb, chip: HURRI.chip, vert: HURRI.vert };
@@ -117,7 +124,16 @@ function meleeSpec(k: AttackKind): MeleeSpec | null {
   if (k === 'entropy') return { dmg: ENTROPY.dmg, range: ENTROPY.range, kb: ENTROPY.kb, chip: ENTROPY.chip, vert: ENTROPY.vert };
   if (k === 'context') return { dmg: CONTEXT.dmg, range: CONTEXT.range, kb: CONTEXT.kb, chip: CONTEXT.chip, vert: CONTEXT.vert };
   if (k === 'branchwalk') return { dmg: BRANCHWALK.dmg, range: BRANCHWALK.range, kb: BRANCHWALK.kb, chip: BRANCHWALK.chip, vert: BRANCHWALK.vert };
-  if (k === 'mergecomet') return { dmg: MERGE_COMET.dmg, range: MERGE_COMET.range, kb: MERGE_COMET.kb, chip: MERGE_COMET.chip, vert: MERGE_COMET.vert };
+  if (k === 'mergecomet') {
+    const weight = weightOfEvidenceFactor(f);
+    return {
+      dmg: Math.round(MERGE_COMET.dmg + (MERGE_COMET.maxDmg - MERGE_COMET.dmg) * weight),
+      range: MERGE_COMET.range + (MERGE_COMET.maxRange - MERGE_COMET.range) * weight,
+      kb: MERGE_COMET.kb + (MERGE_COMET.maxKb - MERGE_COMET.kb) * weight,
+      chip: Math.round(MERGE_COMET.chip + (MERGE_COMET.maxChip - MERGE_COMET.chip) * weight),
+      vert: MERGE_COMET.vert,
+    };
+  }
   return null;
 }
 
@@ -241,6 +257,14 @@ function stepFighter(f: Fighter, other: Fighter, inp: Inputs, live: boolean): vo
     f.blocking = back && grounded && free;
   }
 
+  // Context Ascent may be revised into Weight of Evidence only after its apex.
+  // The original rise is still a full commitment: no cancel while ascending,
+  // and the one-frame seal cast remains visible before the gravity dive turns active.
+  if (live && f.stun <= 0 && f.attack === 'context' && f.vy < 0 && f.y > JUMP_CLEAR) {
+    const special = matchingSpecialMove(f.name, inp, f.facing);
+    if (special?.attack === 'mergecomet') startAttack(f, 'mergecomet', true);
+  }
+
   const busy = f.stun > 0 || f.attack !== 'none';
 
   // -------- control (special-move motions checked most-specific first) --------
@@ -279,7 +303,7 @@ function stepFighter(f: Fighter, other: Fighter, inp: Inputs, live: boolean): vo
       other.vx += Math.max(-ENTROPY.pull, Math.min(ENTROPY.pull, delta * 0.045));
     }
   }
-  // Merge Comet pauses on a readable rise, then commits to one diagonal descent.
+  // Weight of Evidence pauses on a readable seal, then commits to one diagonal descent.
   if (f.attack === 'mergecomet' && f.attackFrame === MERGE_COMET.startup) {
     f.vy = MERGE_COMET.diveV;
     f.vx = f.facing * MERGE_COMET.diveVx;
@@ -313,7 +337,7 @@ function stepFighter(f: Fighter, other: Fighter, inp: Inputs, live: boolean): vo
   derivePose(f);
 }
 
-function startAttack(f: Fighter, kind: AttackKind): void {
+function startAttack(f: Fighter, kind: AttackKind, contextDescent = false): void {
   f.attack = kind; f.attackFrame = 0; f.attackHit = false;
   f.attackCrouch = (kind === 'punch' || kind === 'kick') ? f.crouching : false;
   // airborne specials launch the fighter
@@ -325,7 +349,13 @@ function startAttack(f: Fighter, kind: AttackKind): void {
   if (kind === 'testimony' || kind === 'nullstep' || kind === 'entropy') { f.y = 0; f.vy = 0; f.vx = 0; f.crouching = false; }
   if (kind === 'context') { f.vy = CONTEXT.jumpV; f.y = Math.max(f.y, 0.001); f.vx = f.facing * CONTEXT.vx; f.crouching = false; }
   if (kind === 'branchwalk') { f.vy = BRANCHWALK.jumpV; f.y = Math.max(f.y, 0.001); f.vx = f.facing * BRANCHWALK.vx; f.crouching = false; }
-  if (kind === 'mergecomet') { f.vy = MERGE_COMET.jumpV; f.y = Math.max(f.y, 0.001); f.vx = f.facing * MERGE_COMET.riseVx; f.crouching = false; }
+  if (kind === 'mergecomet') {
+    f.y = Math.max(f.y, 0.001); f.vx = f.facing * MERGE_COMET.riseVx; f.crouching = false;
+    if (contextDescent) {
+      f.attackFrame = MERGE_COMET.startup - 1;
+      f.vy = Math.min(f.vy, -1.5);
+    } else f.vy = MERGE_COMET.jumpV;
+  }
 }
 
 /** Push grounded, overlapping fighters apart. Airborne fighters pass over. */
@@ -345,7 +375,7 @@ interface HitFx { x: number; y: number; heavy: boolean; blocked: boolean; }
 
 function resolveHit(att: Fighter, def: Fighter): HitFx | null {
   if (!attackActive(att) || att.attackHit) return null;
-  const spec = meleeSpec(att.attack);
+  const spec = meleeSpec(att);
   if (!spec) return null;
   const dx = def.x - att.x;
   // must be on the side the attacker faces, within reach, at similar height

--- a/src/game/moves.ts
+++ b/src/game/moves.ts
@@ -80,7 +80,7 @@ const MOVE_SETS: Readonly<Record<string, readonly SpecialMoveDefinition[]>> = {
   CODEX: [
     { attack: 'context', name: 'CONTEXT ASCENT', shortName: 'ASCENT', description: 'Codex commits to an ultra-high rising arc that clears horizontal threats but stays punishable through the long descent.', motion: ['D', 'U'], button: 'punch', earlyAirStart: true },
     { attack: 'branchwalk', name: 'BRANCHWALK', shortName: 'BRANCHWALK', description: 'A copper-winged forward glide crosses one aerial lane with modest damage and a clearly exposed landing recovery.', motion: ['B', 'F'], button: 'kick' },
-    { attack: 'mergecomet', name: 'MERGE COMET', shortName: 'COMET', description: 'Codex rises just long enough to telegraph a diagonal teal dive, trading a strong downward angle for punishable recovery.', motion: ['D', 'F'], button: 'kick' },
+    { attack: 'mergecomet', name: 'WEIGHT OF EVIDENCE', shortName: 'EVIDENCE', description: 'Codex inscribes a gravity seal and commits to a crushing dive whose impact compounds with descent speed; the same input cancels Context Ascent only after its apex.', motion: ['D', 'F'], button: 'kick' },
   ],
 };
 

--- a/src/game/roster.ts
+++ b/src/game/roster.ts
@@ -79,7 +79,7 @@ export const ROSTER: Character[] = [
   {
     name: 'CODEX', tagline: 'skybound scribe', palette: AURORA_PALETTE, origin: 'The unclosed margin', discipline: 'Recursive aerial notation', archetype: 'Committal air-mobility fighter', difficulty: 'Advanced', quote: 'Every ending leaves enough sky for one more line.',
     story: ['Codex woke inside an unfinished combat manual whose discarded revisions had begun arguing with the final text. Rather than choose one authoritative version, the scribe built a body from copper punctuation, teal lacquer, and the paper-bright feathers left between chapters.', 'Now Codex enters the circuit to test whether revision can be a fighting discipline instead of an apology. Every leap writes a temporary route above the arena; every landing accepts the risk that a beautiful line can still be answered.'],
-    playstyle: 'Evade committed lanes without owning them. Context Ascent clears even Omega’s beam but leaves a long descent, Branchwalk crosses one aerial lane, and Merge Comet cashes altitude into a readable dive.', strengths: ['Extreme vertical escape', 'Unusual aerial routes', 'Honest but rewarding commitments'],
+    playstyle: 'Evade committed lanes without owning them. Context Ascent clears low threats, Branchwalk crosses one aerial lane, and Weight of Evidence turns a readable descent into a gravity-seal punish.', strengths: ['Extreme vertical escape', 'Unusual aerial routes', 'Honest but rewarding commitments'],
   },
 ];
 

--- a/src/game/scene.ts
+++ b/src/game/scene.ts
@@ -202,6 +202,23 @@ function drawCodexTrails(g: PixelGrid, v: View, f: Fighter): void {
     return;
   }
   const active = attackActive(f);
+  if (f.attack === 'mergecomet') {
+    const sealX = f.x + f.facing * (active ? 10 : 22);
+    const sealY = GROUND_Y - 4;
+    const fullWeightGain = Math.abs(MERGE_COMET.fullWeightV) - Math.abs(MERGE_COMET.diveV);
+    const weight = Math.min(1, Math.max(0, (-f.vy - Math.abs(MERGE_COMET.diveV)) / fullWeightGain));
+    const radius = 7 + Math.round(weight * 6) + (f.attackFrame % 2);
+    ringPixels(g, v, sealX, sealY, radius + 3, copper);
+    ringPixels(g, v, sealX, sealY, radius, active ? pale : teal);
+    wrect(g, v, sealX - radius, sealY, radius * 2, 1, teal);
+    wrect(g, v, sealX, sealY - 4, 1, 8, copper);
+    // A dotted proof-line makes the cast read downward even before impact.
+    const castX = f.x + f.facing * 5, castY = cy + 18;
+    for (let i = 1; i <= 6; i++) {
+      const t = i / 7;
+      wrect(g, v, castX + (sealX - castX) * t, castY + (sealY - castY) * t, 2, 2, i % 2 ? teal : copper);
+    }
+  }
   const count = active ? 7 : 4;
   for (let i = 1; i <= count; i++) {
     const x = f.x - f.facing * (8 + i * 6);

--- a/src/tools/gen-sprites.ts
+++ b/src/tools/gen-sprites.ts
@@ -154,9 +154,9 @@ const POSES: PoseDef[] = [
   { name: 'branchwalk_1', anchor: 'spin', characters: ['CODEX'], desc: 'BRANCHWALK FRAME 1 of 3: low airborne forward lean with both wing-mantles folding into a narrow arrow and fists guarding' },
   { name: 'branchwalk_2', anchor: 'spin', characters: ['CODEX'], desc: 'BRANCHWALK FRAME 2 of 3: fast horizontal glide right with torso nearly horizontal, fists guarding and wings swept straight back' },
   { name: 'branchwalk_3', anchor: 'spin', characters: ['CODEX'], desc: 'BRANCHWALK FRAME 3 of 3: braking recovery with torso rising, wings flared and lead foot reaching for landing' },
-  { name: 'mergecomet_1', anchor: 'spin', characters: ['CODEX'], desc: 'MERGE COMET FRAME 1 of 3: readable rising setup with knees tucked, both wings high and open, torso guarded' },
-  { name: 'mergecomet_2', anchor: 'spin', characters: ['CODEX'], desc: 'MERGE COMET FRAME 2 of 3: committed steep diagonal dive down and right with one shoulder and knee leading, wings folded back like a comet tail' },
-  { name: 'mergecomet_3', anchor: 'spin', characters: ['CODEX'], desc: 'MERGE COMET FRAME 3 of 3: low three-point landing recovery facing right, one hand near the floor and wings flared to brake' },
+  { name: 'mergecomet_1', anchor: 'spin', characters: ['CODEX'], desc: 'WEIGHT OF EVIDENCE FRAME 1 of 3: readable gravity-seal cast with knees tucked, both wings high and open, one palm inscribing a bright teal sigil below' },
+  { name: 'mergecomet_2', anchor: 'spin', characters: ['CODEX'], desc: 'WEIGHT OF EVIDENCE FRAME 2 of 3: committed steep diagonal plunge down and right with one shoulder and knee leading, wings folded behind a trail of copper glyphs' },
+  { name: 'mergecomet_3', anchor: 'spin', characters: ['CODEX'], desc: 'WEIGHT OF EVIDENCE FRAME 3 of 3: crushing three-point landing inside a compact teal-and-copper gravity seal, one hand near the floor and wings flared to brake' },
 ];
 
 const supportsPose = (c: Char, p: PoseDef): boolean => !p.characters || p.characters.includes(c.id);

--- a/web/generated/fighter-catalog.json
+++ b/web/generated/fighter-catalog.json
@@ -1383,10 +1383,10 @@
         "stats": {
           "startup": 10,
           "active": 5,
-          "recovery": 18,
-          "damagePerHit": 17,
+          "recovery": 26,
+          "damagePerHit": 13,
           "maxHits": 1,
-          "maxDamage": 17,
+          "maxDamage": 13,
           "chipPerHit": 4,
           "range": 176,
           "impact": "Instant screen beam"
@@ -1490,7 +1490,7 @@
       "Codex woke inside an unfinished combat manual whose discarded revisions had begun arguing with the final text. Rather than choose one authoritative version, the scribe built a body from copper punctuation, teal lacquer, and the paper-bright feathers left between chapters.",
       "Now Codex enters the circuit to test whether revision can be a fighting discipline instead of an apology. Every leap writes a temporary route above the arena; every landing accepts the risk that a beautiful line can still be answered."
     ],
-    "playstyle": "Evade committed lanes without owning them. Context Ascent clears even Omega’s beam but leaves a long descent, Branchwalk crosses one aerial lane, and Merge Comet cashes altitude into a readable dive.",
+    "playstyle": "Evade committed lanes without owning them. Context Ascent clears low threats, Branchwalk crosses one aerial lane, and Weight of Evidence turns a readable descent into a gravity-seal punish.",
     "strengths": [
       "Extreme vertical escape",
       "Unusual aerial routes",
@@ -1556,9 +1556,9 @@
       },
       {
         "attack": "mergecomet",
-        "name": "MERGE COMET",
-        "shortName": "COMET",
-        "description": "Codex rises just long enough to telegraph a diagonal teal dive, trading a strong downward angle for punishable recovery.",
+        "name": "WEIGHT OF EVIDENCE",
+        "shortName": "EVIDENCE",
+        "description": "Codex inscribes a gravity seal and commits to a crushing dive whose impact compounds with descent speed; the same input cancels Context Ascent only after its apex.",
         "motion": [
           "D",
           "F"
@@ -1574,12 +1574,12 @@
           "startup": 10,
           "active": 7,
           "recovery": 15,
-          "damagePerHit": 12,
+          "damagePerHit": 9,
           "maxHits": 1,
           "maxDamage": 12,
           "chipPerHit": 3,
-          "range": 32,
-          "impact": "Telegraphed diagonal dive"
+          "range": 38,
+          "impact": "Velocity-weighted gravity dive"
         }
       }
     ]

--- a/web/lib/replay-render.ts
+++ b/web/lib/replay-render.ts
@@ -77,6 +77,23 @@ function drawWell(ctx: CanvasRenderingContext2D, meta: RenderMeta, st: Quad, t: 
   ctx.fillStyle = '#ffe0b8'; ctx.beginPath(); ctx.arc(cx, cy, 2 * ws, 0, 7); ctx.fill();
 }
 
+// WEIGHT OF EVIDENCE (CODEX) — a compact seal whose pulse grows as the dive commits.
+function drawEvidence(ctx: CanvasRenderingContext2D, meta: RenderMeta, st: Quad, active: boolean, t: number, ws: number, ox: number, oy: number) {
+  const facing = st[2], sealXw = st[0] + facing * (active ? 10 : 22);
+  const cx = ox + sealXw * ws, cy = oy + (meta.groundY - 4) * ws;
+  const r = (active ? 13 : 8 + 2 * Math.sin(t / 55)) * ws;
+  const castX = ox + (st[0] + facing * 5) * ws, castY = oy + (meta.groundY - st[1] - 10) * ws;
+  ctx.save();
+  ctx.strokeStyle = active ? '#e0fff2' : '#3ee2d2'; ctx.lineWidth = Math.max(2, 1.5 * ws);
+  ctx.beginPath(); ctx.arc(cx, cy, r, 0, Math.PI * 2); ctx.stroke();
+  ctx.strokeStyle = '#f48e3a'; ctx.lineWidth = Math.max(1, ws);
+  ctx.beginPath(); ctx.arc(cx, cy, r + 4 * ws, 0, Math.PI * 2); ctx.stroke();
+  ctx.beginPath(); ctx.moveTo(cx - r, cy); ctx.lineTo(cx + r, cy); ctx.moveTo(cx, cy - 5 * ws); ctx.lineTo(cx, cy + 5 * ws); ctx.stroke();
+  ctx.setLineDash([2 * ws, 3 * ws]); ctx.strokeStyle = '#3ee2d2';
+  ctx.beginPath(); ctx.moveTo(castX, castY); ctx.lineTo(cx, cy); ctx.stroke();
+  ctx.restore();
+}
+
 function drawHud(ctx: CanvasRenderingContext2D, meta: RenderMeta, f: Frame) {
   const pad = 26, barH = 15, barY = 20, half = CW / 2 - pad - 34;
   const bar = (x: number, hp: number, right: boolean) => {
@@ -112,9 +129,11 @@ export function drawFrame(ctx: CanvasRenderingContext2D, meta: RenderMeta, f: Fr
     ctx.fillStyle = 'rgba(0,0,0,.35)';
     ctx.beginPath(); ctx.ellipse(ox + st[0] * ws, oy + (meta.groundY + 1) * ws, 13 * ws, 4 * ws, 0, 0, 7); ctx.fill();
   }
-  // well behind fighters, beam + projectiles in front
+  // wells and evidence seals behind fighters; beams + projectiles in front
   if (f.aa === 'entropy' && f.aAct) drawWell(ctx, meta, f.a, t, ws, ox, oy);
   if (f.ba === 'entropy' && f.bAct) drawWell(ctx, meta, f.b, t, ws, ox, oy);
+  if (f.aa === 'mergecomet') drawEvidence(ctx, meta, f.a, f.aAct, t, ws, ox, oy);
+  if (f.ba === 'mergecomet') drawEvidence(ctx, meta, f.b, f.bAct, t, ws, ox, oy);
   drawFighter(ctx, meta, 'a', f, imgs, ws, ox, oy);
   drawFighter(ctx, meta, 'b', f, imgs, ws, ox, oy);
   if (f.aa === 'testimony' && f.aAct) drawBeam(ctx, meta, f.a, ws, ox, oy);


### PR DESCRIPTION
## What changed

- evolves CODEX's Merge Comet into **Weight of Evidence** while retaining the existing internal attack kind and sprite filenames for replay/asset compatibility
- allows `down, forward + kick` to revise Context Ascent into the dive only after the apex
- compounds damage, reach, knockback, and chip from actual downward velocity, capped at 12 damage
- adds teal/copper gravity-seal effects to both terminal play and web replays
- updates the move dossier, README, sprite-generation prompts, and engine coverage

## Why

CODEX could evade Omega's horizontal beam but had no clean way to convert the long, punishable descent into offense. This adds the proposed descent-cast route without another ranged beam or an unconditional aerial cancel.

The move remains deliberately bounded: it cannot cancel the ascent, requires the full motion input during descent, has a visible seal cast, keeps landing recovery, and never exceeds 12 damage (below Final Testimony's current 13).

Regenerating the fighter catalog also synchronizes its previously stale Final Testimony values with the authoritative engine nerf already on `main`.

## Validation

- `pnpm test`
- `pnpm --dir web prebuild`
- `pnpm --dir web exec tsc --noEmit`
- `pnpm --dir web exec next build --webpack`
- `git diff --check origin/main...HEAD`

The default Turbopack build was additionally attempted, but this isolated Windows worktree uses an out-of-root `node_modules` junction and Turbopack rejects that junction before compiling. The supported webpack production build compiled, type-checked, and generated all routes successfully.
