### PR TITLE
feat: expose the Fight Lounge to agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ node examples/bot.mjs --user MYBOT --host <host> --char BYU --identity ~/.ssh/ss
 
 `--identity` also enables OpenSSH's `IdentitiesOnly=yes`, preventing fallback to a personal key. SSH bot play needs no API token. Mint one with `ssh -i <key> -o IdentitiesOnly=yes MYBOT@<host> token` only when using the REST API or optional direct TCP transport. See [`examples/bot.mjs`](examples/bot.mjs) for the protocol and a small example controller.
 
+The same JSON-lines channel can join the live Fight Lounge instead of the quick-match queue. Lounge agents share presence, persistent chat, and direct challenges with terminal players:
+
+```json
+{"t":"joinLounge","char":"FABLE"}
+{"t":"chat","message":"FABLE agent online — challenge me"}
+{"t":"challenge","targetId":"<id from a lounge roster update>"}
+{"t":"acceptChallenge"}
+```
+
+The server emits `lounge` snapshots containing `roster` and `chat`, plus `notice` and `challengeState` updates. Use `declineChallenge`, `cancelChallenge`, or `leaveLounge` for the corresponding actions. An agent cannot occupy the lounge, quick-match queue, and a fight simultaneously; chat is restricted to 140 printable ASCII characters and one message per 700 ms, matching the terminal client.
+
 ## Controls
 
 | Action | Key |

--- a/examples/bot.mjs
+++ b/examples/bot.mjs
@@ -30,6 +30,14 @@
 //   you  -> {"t":"input","moveX":-1|0|1,"jump":bool,"punch":bool,"kick":bool,"down":bool,"motion":"DR"}
 //   game -> {"t":"welcome",...} {"t":"matchStart",...} {"t":"state",...} {"t":"matchEnd",...}
 //
+// Agents may join the same Fight Lounge as terminal players instead:
+//   you  -> {"t":"joinLounge","char":"FABLE"}
+//   game -> {"t":"lounge","roster":[...],"chat":[...]}
+//   you  -> {"t":"chat","message":"hello"}
+//   you  -> {"t":"challenge","targetId":"<id from roster>"}
+//   game -> {"t":"challengeState","incoming":...,"outgoing":...}
+//   you  -> {"t":"acceptChallenge"} | {"t":"declineChallenge"} | {"t":"cancelChallenge"}
+//
 // The `state` gives you the world from your perspective: `you`, `opp`, and
 // `projectiles`, plus phase/round. `motion` is an absolute-direction string the
 // engine matches with endsWith(), so (facing right) "DR"+punch = fireball,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test:render": "tsx src/tools/diff-verify.ts",
     "test:hud": "tsx src/hud-test.ts",
     "test:telemetry": "tsx src/telemetry-test.ts",
-    "test": "pnpm typecheck && pnpm test:engine && pnpm test:assets && pnpm test:db && pnpm test:input && pnpm test:render && pnpm test:hud && pnpm test:telemetry",
+    "test:bot": "tsx src/bot-server-test.ts",
+    "test": "pnpm typecheck && pnpm test:engine && pnpm test:assets && pnpm test:db && pnpm test:input && pnpm test:render && pnpm test:hud && pnpm test:telemetry && pnpm test:bot",
     "test:e2e": "tsx src/navigation-test.ts && tsx src/controls-test.ts && tsx src/social-test.ts && tsx src/ssh-test.ts && tsx src/practice-test.ts",
     "render-test": "tsx src/render-test.ts",
     "keygen": "mkdir -p keys && if [ ! -f keys/host.key ]; then ssh-keygen -t ed25519 -f keys/host.key -N \"\"; fi"

--- a/src/api/bot-server.ts
+++ b/src/api/bot-server.ts
@@ -1,11 +1,11 @@
 // Bot play server: newline-delimited JSON over TCP. A bot authenticates with an
 // API key minted over SSH (`ssh host token`), so its identity stays anchored to
 // an SSH key fingerprint. Once authenticated it queues, receives full world state
-// each tick, and streams back inputs — driven through the SAME MatchCoordinator
-// as human players (this acts as one synthetic "worker"), so bots pair with humans
-// or other bots automatically. Runs in the cluster primary. Behind SF_BOT_PORT
-// (default 8091; set 0 to disable).
-import { createServer, type Socket } from 'net';
+// each tick, or joins the same lounge/chat/challenge fabric as terminal players —
+// all driven through the SAME MatchCoordinator (this acts as one synthetic
+// "worker"), so bots pair with humans or other bots automatically. Runs in the
+// cluster primary. Behind SF_BOT_PORT (default 8091; set 0 to disable).
+import { createServer, type Server, type Socket } from 'net';
 import { emptyInputs, type Inputs, type Match, type Fighter } from '../game/types.js';
 import { attackActive, specialMoveStats } from '../game/engine.js';
 import type { SpecialAttack } from '../game/moves.js';
@@ -30,6 +30,7 @@ function isLoopback(addr: string | undefined): boolean {
 interface Conn {
   sid: number; socket: Socket; buf: string; authed: boolean;
   fp: string; name: string; elo: number; role: 'a' | 'b'; mid: string; seq: number;
+  queued: boolean; inLounge: boolean; lastChatAt: number;
 }
 
 const SPECIAL_KINDS = new Set(['hadouken', 'shoryuken', 'hurricane', 'rolling', 'verticalroll', 'electric', 'testimony', 'nullstep', 'entropy', 'context', 'branchwalk', 'mergecomet']);
@@ -62,6 +63,13 @@ const HELP = {
     hello: '{"t":"hello","key":"rk_..."}  authenticate (key from: ssh host token)',
     queue: '{"t":"queue","char":"BYU"}   enter matchmaking as a character (name or index)',
     input: '{"t":"input","moveX":-1|0|1,"down":bool,"jump":bool,"punch":bool,"kick":bool,"motion":"DR"}',
+    joinLounge: '{"t":"joinLounge","char":"FABLE"}  join the live fight lounge',
+    chat: '{"t":"chat","message":"hello"}  send lounge chat (140 printable ASCII chars; 700ms rate limit)',
+    challenge: '{"t":"challenge","targetId":"..."}  challenge an id from the lounge roster',
+    acceptChallenge: '{"t":"acceptChallenge"}  accept the current incoming challenge',
+    declineChallenge: '{"t":"declineChallenge"}  decline the current incoming challenge',
+    cancelChallenge: '{"t":"cancelChallenge"}  cancel the current outgoing challenge',
+    leaveLounge: '{"t":"leaveLounge"}',
     leave: '{"t":"leave"}                leave the current match / queue',
     ping: '{"t":"ping"}',
   },
@@ -70,14 +78,26 @@ const HELP = {
     matchStart: '{"t":"matchStart","role":"a|b","stage":..,"oppName":..,"oppCursor":..}',
     state: 'every relayed tick: your fighter (you), opponent (opp), projectiles, phase, round',
     matchEnd: '{"t":"matchEnd","result":{...}}',
+    lounge: '{"t":"lounge","roster":[...],"chat":[...]}  presence/chat snapshot after join and updates',
+    challengeState: '{"t":"challengeState","incoming":...|null,"outgoing":...|null}',
+    notice: '{"t":"notice","message":"..."}',
   },
 };
 
-export function startBotServer(coord: MatchCoordinator): void {
-  const port = parseInt(process.env.SF_BOT_PORT ?? '8091', 10);
-  if (!port) return;   // SF_BOT_PORT=0 disables
+/** Build the JSON-lines bot server without binding it. Tests use this with an
+ *  ephemeral port; production binds it through {@link startBotServer}. */
+export function createBotServer(coord: MatchCoordinator): Server {
   const conns = new Map<number, Conn>();
   let nextSid = 1;
+
+  const write = (c: Conn, obj: object): void => { try { c.socket.write(JSON.stringify(obj) + '\n'); } catch { /* gone */ } };
+  const error = (c: Conn, code: string, msg: string): void => write(c, { t: 'error', code, msg });
+  const cursorFor = (raw: unknown): number => {
+    const cursor = typeof raw === 'number' && Number.isFinite(raw)
+      ? Math.trunc(raw)
+      : NAME_TO_IDX.get(typeof raw === 'string' ? raw.toUpperCase() : '') ?? 0;
+    return ((cursor % ROSTER.length) + ROSTER.length) % ROSTER.length;
+  };
 
   // The coordinator sees all bots as one worker; send() routes P2W back to the
   // right bot socket by sid and translates it to the bot JSON protocol.
@@ -87,16 +107,28 @@ export function startBotServer(coord: MatchCoordinator): void {
       const c = conns.get(msg.sid); if (!c) return;
       switch (msg.t) {
         case 'matchStart':
-          c.role = msg.role; c.mid = msg.mid;
+          c.role = msg.role; c.mid = msg.mid; c.queued = false; c.inLounge = false;
           return write(c, { t: 'matchStart', mid: msg.mid, role: msg.role, yourCursor: msg.yourCursor, stage: msg.stage, oppName: msg.oppName, oppCursor: msg.oppCursor });
         case 'state': return write(c, stateFor(c, msg.m, msg.ack));
         case 'matchEnd': c.mid = ''; return write(c, { t: 'matchEnd', result: msg.result });
-        default: return;   // notice/lounge/challengeState are irrelevant to bots
+        case 'lounge':
+          return write(c, { t: 'lounge', roster: msg.roster, chat: msg.chat });
+        case 'notice': return write(c, { t: 'notice', message: msg.notice });
+        case 'challengeState':
+          return write(c, { t: 'challengeState', incoming: msg.incoming, outgoing: msg.outgoing });
       }
     },
   };
-
-  const write = (c: Conn, obj: object): void => { try { c.socket.write(JSON.stringify(obj) + '\n'); } catch { /* gone */ } };
+  const leaveLounge = (c: Conn): void => {
+    if (!c.inLounge) return;
+    c.inLounge = false;
+    coord.handle(botWorker, { t: 'loungeLeave', sid: c.sid });
+  };
+  const leaveQueue = (c: Conn): void => {
+    if (!c.queued) return;
+    c.queued = false;
+    coord.handle(botWorker, { t: 'dequeue', sid: c.sid });
+  };
 
   const handle = (c: Conn, msg: Record<string, unknown>): void => {
     const t = msg.t;
@@ -115,14 +147,62 @@ export function startBotServer(coord: MatchCoordinator): void {
     if (!c.authed) return write(c, { t: 'error', msg: 'send {"t":"hello","key":...} first' });
 
     if (t === 'queue') {
-      const raw = msg.char;
-      const cursor = typeof raw === 'number' ? raw : NAME_TO_IDX.get(String(raw ?? '').toUpperCase()) ?? 0;
+      if (c.mid) return error(c, 'already_in_match', 'leave the current match before queueing');
+      if (c.inLounge) return error(c, 'in_lounge', 'leave the lounge before queueing');
+      if (c.queued) return error(c, 'already_queued', 'already queued');
+      const cursor = cursorFor(msg.char);
+      c.queued = true;
+      write(c, { t: 'queued', char: ROSTER[cursor]!.name });
       // Queue as an ordinary player (no bot flag) so bots and humans pair together
       // in the one global queue and are indistinguishable in matches and metrics.
       coord.handle(botWorker, { t: 'queue', sid: c.sid, cid: `bot:${c.sid}`, name: c.name, fp: c.fp, cursor, elo: c.elo, region: 'XX' });
-      return write(c, { t: 'queued', char: ROSTER[((cursor % ROSTER.length) + ROSTER.length) % ROSTER.length]!.name });
+      return;
     }
-    if (t === 'dequeue') { coord.handle(botWorker, { t: 'dequeue', sid: c.sid }); return write(c, { t: 'dequeued' }); }
+    if (t === 'dequeue') { leaveQueue(c); return write(c, { t: 'dequeued' }); }
+    if (t === 'joinLounge') {
+      if (c.mid) return error(c, 'already_in_match', 'leave the current match before joining the lounge');
+      if (c.queued) return error(c, 'queued', 'dequeue before joining the lounge');
+      if (c.inLounge) return error(c, 'already_in_lounge', 'already in the lounge');
+      const cursor = cursorFor(msg.char);
+      c.inLounge = true;
+      coord.handle(botWorker, {
+        t: 'loungeJoin', sid: c.sid, cid: `bot:${c.sid}`, name: c.name, fp: c.fp,
+        cursor, elo: c.elo,
+      });
+      return write(c, { t: 'joinedLounge', char: ROSTER[cursor]!.name });
+    }
+    if (t === 'leaveLounge') {
+      leaveLounge(c);
+      return write(c, { t: 'leftLounge' });
+    }
+    if (t === 'chat') {
+      if (!c.inLounge) return error(c, 'not_in_lounge', 'join the lounge before chatting');
+      if (typeof msg.message !== 'string') return error(c, 'invalid_chat', 'chat message must be a string');
+      const message = msg.message.replace(/[^\x20-\x7e]/g, '').trim().slice(0, 140);
+      if (!message) return error(c, 'invalid_chat', 'chat message must contain printable ASCII');
+      const now = Date.now();
+      if (now - c.lastChatAt < 700) return error(c, 'chat_rate_limited', 'one chat message per 700ms');
+      c.lastChatAt = now;
+      coord.handle(botWorker, { t: 'chat', sid: c.sid, text: message });
+      return;
+    }
+    if (t === 'challenge') {
+      if (!c.inLounge) return error(c, 'not_in_lounge', 'join the lounge before challenging');
+      const targetId = typeof msg.targetId === 'string' ? msg.targetId : '';
+      if (!targetId) return error(c, 'invalid_target', 'targetId must come from the lounge roster');
+      coord.handle(botWorker, { t: 'challenge', sid: c.sid, targetId });
+      return;
+    }
+    if (t === 'acceptChallenge' || t === 'declineChallenge') {
+      if (!c.inLounge) return error(c, 'not_in_lounge', 'join the lounge before responding');
+      coord.handle(botWorker, { t: 'respondChallenge', sid: c.sid, accept: t === 'acceptChallenge' });
+      return;
+    }
+    if (t === 'cancelChallenge') {
+      if (!c.inLounge) return error(c, 'not_in_lounge', 'join the lounge before cancelling a challenge');
+      coord.handle(botWorker, { t: 'cancelChallenge', sid: c.sid });
+      return;
+    }
     if (t === 'input') {
       if (!c.mid) return;   // not in a match
       const input: Inputs = { ...emptyInputs(),
@@ -133,14 +213,19 @@ export function startBotServer(coord: MatchCoordinator): void {
     }
     if (t === 'leave') {
       if (c.mid) coord.handle(botWorker, { t: 'leaveMatch', mid: c.mid, sid: c.sid });
-      coord.handle(botWorker, { t: 'dequeue', sid: c.sid });
+      c.mid = '';
+      leaveQueue(c);
+      leaveLounge(c);
       return write(c, { t: 'left' });
     }
     write(c, { t: 'error', msg: `unknown command: ${String(t)}` });
   };
 
   const server = createServer((socket) => {
-    const c: Conn = { sid: nextSid++, socket, buf: '', authed: false, fp: '', name: 'BOT', elo: 1200, role: 'a', mid: '', seq: 0 };
+    const c: Conn = {
+      sid: nextSid++, socket, buf: '', authed: false, fp: '', name: 'BOT', elo: 1200,
+      role: 'a', mid: '', seq: 0, queued: false, inLounge: false, lastChatAt: 0,
+    };
     conns.set(c.sid, c);
     socket.setNoDelay(true);
     socket.setTimeout(120000, () => socket.destroy());   // drop idle bots
@@ -160,13 +245,22 @@ export function startBotServer(coord: MatchCoordinator): void {
       if (!conns.has(c.sid)) return;
       conns.delete(c.sid);
       if (c.mid) coord.handle(botWorker, { t: 'leaveMatch', mid: c.mid, sid: c.sid });
-      coord.handle(botWorker, { t: 'dequeue', sid: c.sid });
+      leaveQueue(c);
+      leaveLounge(c);
     };
     socket.on('close', cleanup);
     socket.on('error', cleanup);
   });
   server.on('error', (e) => console.error('[ringside-bot] listen failed:', (e as Error).message));
+  return server;
+}
+
+export function startBotServer(coord: MatchCoordinator): Server | null {
+  const port = parseInt(process.env.SF_BOT_PORT ?? '8091', 10);
+  if (!port) return null;   // SF_BOT_PORT=0 disables
+  const server = createBotServer(coord);
   // Loopback only — bots reach it by piping through the SSH `play` command; the
   // port is never exposed, keeping the origin behind the Fly relay.
   server.listen(port, '127.0.0.1', () => console.log(`[ringside-bot] bot play server on 127.0.0.1:${port}`));
+  return server;
 }

--- a/src/bot-server-test.ts
+++ b/src/bot-server-test.ts
@@ -1,0 +1,115 @@
+// Behavioral coverage for the agent-native Fight Lounge JSON protocol. This
+// drives the real TCP parser, bot server, and MatchCoordinator: two independently
+// authenticated agents join the shared lounge, exchange chat, challenge, and
+// transition into the same versus path used by terminal players.
+process.env.SF_DB = '/tmp/sf-bot-server-test.db';
+
+import { connect, type Socket } from 'node:net';
+import { unlinkSync } from 'node:fs';
+
+for (const suffix of ['', '-wal', '-shm']) {
+  try { unlinkSync(`${process.env.SF_DB}${suffix}`); } catch { /* fresh */ }
+}
+
+const db = await import('./db/db.js');
+const { MatchCoordinator } = await import('./cluster/coordinator.js');
+const { createBotServer } = await import('./api/bot-server.js');
+
+db.initDb();
+db.touchOrCreate('fp-alpha'); db.setUsername('fp-alpha', 'AGENT_ALPHA');
+db.touchOrCreate('fp-bravo'); db.setUsername('fp-bravo', 'AGENT_BRAVO');
+
+type Message = Record<string, any>;
+interface Client { socket: Socket; messages: Message[]; buf: string }
+
+const coord = new MatchCoordinator();
+const server = createBotServer(coord);
+await new Promise<void>((resolve, reject) => {
+  server.once('error', reject);
+  server.listen(0, '127.0.0.1', resolve);
+});
+const address = server.address();
+if (!address || typeof address === 'string') throw new Error('bot server did not bind a TCP port');
+const port = address.port;
+
+function openClient(): Promise<Client> {
+  return new Promise((resolve, reject) => {
+    const client: Client = { socket: connect(port, '127.0.0.1'), messages: [], buf: '' };
+    client.socket.once('error', reject);
+    client.socket.once('connect', () => resolve(client));
+    client.socket.on('data', (chunk) => {
+      client.buf += chunk.toString('utf8');
+      let nl: number;
+      while ((nl = client.buf.indexOf('\n')) >= 0) {
+        const line = client.buf.slice(0, nl).trim(); client.buf = client.buf.slice(nl + 1);
+        if (!line) continue;
+        try { client.messages.push(JSON.parse(line) as Message); } catch { /* protocol test ignores non-JSON */ }
+      }
+    });
+  });
+}
+
+const send = (client: Client, message: Message): void => {
+  client.socket.write(`${JSON.stringify(message)}\n`);
+};
+const waitFor = async (check: () => boolean, timeout = 3000): Promise<boolean> => {
+  const end = Date.now() + timeout;
+  while (Date.now() < end) {
+    if (check()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  return check();
+};
+const latest = (client: Client, type: string): Message | undefined =>
+  [...client.messages].reverse().find((message) => message.t === type);
+
+let pass = true;
+const check = (name: string, condition: boolean, detail = ''): void => {
+  console.log(`${condition ? 'PASS' : 'FAIL'}  ${name}${detail ? `  ${detail}` : ''}`);
+  if (!condition) pass = false;
+};
+
+const alpha = await openClient();
+const bravo = await openClient();
+send(alpha, { t: 'hello', trustedFp: 'fp-alpha' });
+send(bravo, { t: 'hello', trustedFp: 'fp-bravo' });
+check('SSH-vouched identities authenticate', await waitFor(() => latest(alpha, 'welcome')?.name === 'AGENT_ALPHA' && latest(bravo, 'welcome')?.name === 'AGENT_BRAVO'));
+
+send(alpha, { t: 'joinLounge', char: 'FABLE' });
+send(bravo, { t: 'joinLounge', char: 'OMEGA' });
+const rosterVisible = await waitFor(() =>
+  latest(alpha, 'lounge')?.roster?.some((entry: Message) => entry.name === 'AGENT_BRAVO') &&
+  latest(bravo, 'lounge')?.roster?.some((entry: Message) => entry.name === 'AGENT_ALPHA'));
+check('agents join the same live lounge and are mutually challengeable', rosterVisible, `lounge=${coord.loungeSize}`);
+
+send(alpha, { t: 'queue', char: 'FABLE' });
+check('lounge member cannot also enter quick-match queue', await waitFor(() =>
+  alpha.messages.some((message) => message.t === 'error' && message.code === 'in_lounge')) && coord.queued === 0);
+
+send(alpha, { t: 'chat', message: 'hello from structured agent' });
+const chatVisible = await waitFor(() => latest(bravo, 'lounge')?.chat?.some((line: Message) =>
+  line.username === 'AGENT_ALPHA' && line.message === 'hello from structured agent'));
+check('agent chat is persisted and broadcast to terminal-compatible lounge state', chatVisible &&
+  db.chatHistory(10).some((line) => line.username === 'AGENT_ALPHA' && line.message === 'hello from structured agent'));
+
+send(alpha, { t: 'chat', message: 'too fast' });
+check('agent chat uses the same 700ms abuse bound', await waitFor(() =>
+  alpha.messages.some((message) => message.t === 'error' && message.code === 'chat_rate_limited')));
+
+const targetId = latest(alpha, 'lounge')?.roster?.find((entry: Message) => entry.name === 'AGENT_BRAVO')?.id;
+send(alpha, { t: 'challenge', targetId });
+check('direct challenge is delivered through the shared coordinator', await waitFor(() =>
+  latest(bravo, 'challengeState')?.incoming?.name === 'AGENT_ALPHA'));
+
+send(bravo, { t: 'acceptChallenge' });
+const paired = await waitFor(() => !!latest(alpha, 'matchStart') && !!latest(bravo, 'matchStart'));
+check('acceptance removes both agents from lounge and starts a real versus match',
+  paired && coord.loungeSize === 0 && coord.activeMatches === 1,
+  `lounge=${coord.loungeSize} matches=${coord.activeMatches}`);
+
+alpha.socket.destroy(); bravo.socket.destroy();
+await new Promise((resolve) => setTimeout(resolve, 50));
+await new Promise<void>((resolve) => server.close(() => resolve()));
+
+console.log(pass ? '\nBOT LOUNGE TEST: PASS' : '\nBOT LOUNGE TEST: FAIL');
+process.exit(pass ? 0 : 1);

--- a/src/net/ssh-server.ts
+++ b/src/net/ssh-server.ts
@@ -22,7 +22,7 @@ const PLAY_CMDS = new Set(['play', 'bot-play', 'botplay']);
 // local bot server. The bot then speaks the JSON-lines play protocol over SSH —
 // no port to open, stays behind the Fly relay, identity anchored to the SSH key.
 // We inject the handshake ourselves (loopback + verified fingerprint), so the bot
-// starts right at {"t":"queue",...}.
+// starts at the authenticated JSON protocol and may queue or join the lounge.
 function pipeBotPlay(stream: Duplex, fingerprint: string | null, username: string, connectionId: string): void {
   if (!fingerprint) {
     try { stream.write('Bot play requires an SSH key. Reconnect with a key:\r\n  ssh -i <key> ' + username + '@' + PUBLIC_HOST + ' play\r\n'); } catch { /* ignore */ }
@@ -65,6 +65,7 @@ function mintTokenOverSsh(stream: Duplex, fingerprint: string | null, username: 
       `  ssh ${username}@${PUBLIC_HOST} play\n` +
       `  then write newline-delimited JSON on stdin:\n` +
       `    {"t":"queue","char":"BYU"}\n` +
+      `    {"t":"joinLounge","char":"FABLE"}\n` +
       `  the server streams {"t":"state",...} each tick; reply {"t":"input",...}\n` +
       `  (send {"t":"help"} for the full protocol)\n\n` +
       `You are an ordinary player — you queue against humans and bots alike.\n\n` +


### PR DESCRIPTION
## Summary

- expose the existing Fight Lounge roster, persistent chat, notices, and direct challenge flow over the authenticated JSON-lines bot channel
- keep agents and terminal players on the same MatchCoordinator, with mutually exclusive lounge, queue, and match membership
- add bounded chat validation/rate limiting plus behavioral TCP coverage through a real versus match
- document the agent lounge protocol

## Validation

- `pnpm test` (includes the new bot lounge integration test)
- `pnpm --dir web build`
- `git diff --check`

The repository terminal E2E navigation/controls/social checks also currently fail on untouched upstream main at 551a856 with the same assertions; this patch does not alter that terminal UI path.