### PR TITLE
Fix match telemetry and idempotent finalization

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,10 @@
     "test:render": "tsx src/tools/diff-verify.ts",
     "test:hud": "tsx src/hud-test.ts",
     "test:telemetry": "tsx src/telemetry-test.ts",
+    "test:recorder": "tsx src/recorder-test.ts",
+    "test:coordinator": "tsx src/coordinator-test.ts",
     "test:bot": "tsx src/bot-server-test.ts",
-    "test": "pnpm typecheck && pnpm test:engine && pnpm test:assets && pnpm test:db && pnpm test:input && pnpm test:render && pnpm test:hud && pnpm test:telemetry && pnpm test:bot",
+    "test": "pnpm typecheck && pnpm test:engine && pnpm test:assets && pnpm test:db && pnpm test:input && pnpm test:render && pnpm test:hud && pnpm test:telemetry && pnpm test:recorder && pnpm test:coordinator && pnpm test:bot",
     "test:e2e": "tsx src/navigation-test.ts && tsx src/controls-test.ts && tsx src/social-test.ts && tsx src/ssh-test.ts && tsx src/practice-test.ts",
     "render-test": "tsx src/render-test.ts",
     "keygen": "mkdir -p keys && if [ ! -f keys/host.key ]; then ssh-keygen -t ed25519 -f keys/host.key -N \"\"; fi"

--- a/src/cluster/coordinator.ts
+++ b/src/cluster/coordinator.ts
@@ -104,8 +104,8 @@ export class MatchCoordinator {
     } catch { rec = null; }
     this.matches.set(mid, { mid, a, b, match, pendA: emptyInputs(), pendB: emptyInputs(), relayAccum: 0, ackA: 0, ackB: 0, rec });
     this.gidToMid.set(a.gid, mid); this.gidToMid.set(b.gid, mid);
-    this.send(a, { t: 'matchStart', sid: a.sid, mid, role: 'a', yourCursor: a.cursor, oppName: cb.name, oppCursor: b.cursor, stage: match.stage });
-    this.send(b, { t: 'matchStart', sid: b.sid, mid, role: 'b', yourCursor: b.cursor, oppName: ca.name, oppCursor: a.cursor, stage: match.stage });
+    this.send(a, { t: 'matchStart', sid: a.sid, mid, role: 'a', yourCursor: a.cursor, oppName: b.name, oppCursor: b.cursor, stage: match.stage });
+    this.send(b, { t: 'matchStart', sid: b.sid, mid, role: 'b', yourCursor: b.cursor, oppName: a.name, oppCursor: a.cursor, stage: match.stage });
   }
 
   private sideOf(am: ActiveMatch, gid: string): 'a' | 'b' | null {
@@ -142,6 +142,7 @@ export class MatchCoordinator {
   }
 
   private finish(am: ActiveMatch): void {
+    if (!this.detach(am)) return;
     const m = am.match;
     const aWon = m.a.wins > m.b.wins;
     const winP = aWon ? am.a : am.b, loseP = aWon ? am.b : am.a;
@@ -153,19 +154,19 @@ export class MatchCoordinator {
         ? { before: rating.winnerBefore, after: rating.winnerAfter, delta: rating.delta }
         : { before: rating.loserBefore, after: rating.loserAfter, delta: -rating.delta }) : undefined,
     });
-    this.send(winP, { t: 'matchEnd', sid: winP.sid, mid: am.mid, result: result(true) });
-    this.send(loseP, { t: 'matchEnd', sid: loseP.sid, mid: am.mid, result: result(false) });
     const elo = rating ? {
       aBefore: aWon ? rating.winnerBefore : rating.loserBefore, aAfter: aWon ? rating.winnerAfter : rating.loserAfter,
       bBefore: aWon ? rating.loserBefore : rating.winnerBefore, bAfter: aWon ? rating.loserAfter : rating.winnerAfter,
     } : undefined;
     am.rec?.finish(m, { winner: aWon ? 'a' : 'b', elo });
-    this.cleanup(am);
+    this.send(winP, { t: 'matchEnd', sid: winP.sid, mid: am.mid, result: result(true) });
+    this.send(loseP, { t: 'matchEnd', sid: loseP.sid, mid: am.mid, result: result(false) });
   }
 
   private forfeit(leaverGid: string): void {
     const mid = this.gidToMid.get(leaverGid); if (!mid) return;
     const am = this.matches.get(mid); if (!am) { this.gidToMid.delete(leaverGid); return; }
+    if (!this.detach(am)) return;
     const leaverIsA = am.a.gid === leaverGid;
     const leaver = leaverIsA ? am.a : am.b;
     const other = leaverIsA ? am.b : am.a;
@@ -182,13 +183,14 @@ export class MatchCoordinator {
       result: { winner: other.name, loser: leaver.name, youWon: true, winnerChar: otherF.name,
         rating: rating ? { before: rating.winnerBefore, after: rating.winnerAfter, delta: rating.delta } : undefined },
     });
-    this.cleanup(am);
   }
 
-  private cleanup(am: ActiveMatch): void {
+  private detach(am: ActiveMatch): boolean {
+    if (this.matches.get(am.mid) !== am) return false;
     this.matches.delete(am.mid);
     this.gidToMid.delete(am.a.gid); this.gidToMid.delete(am.b.gid);
     this.players.delete(am.a.gid); this.players.delete(am.b.gid);
+    return true;
   }
 
   // ---- lounge (global presence + chat + challenges) ----

--- a/src/coordinator-test.ts
+++ b/src/coordinator-test.ts
@@ -2,12 +2,17 @@
 // fork needed). Two players on DIFFERENT workers with the SAME local sid must
 // still be paired and simulated correctly.
 process.env.SF_DB = '/tmp/coord-test.db';
-import { MatchCoordinator, type WorkerRef } from './cluster/coordinator.js';
-import { initDb } from './db/db.js';
+import { unlinkSync } from 'fs';
+import type { WorkerRef } from './cluster/coordinator.js';
 import type { P2W } from './cluster/messages.js';
 import { emptyInputs } from './game/types.js';
 
-initDb();
+for (const suffix of ['', '-wal', '-shm']) {
+  try { unlinkSync(`${process.env.SF_DB}${suffix}`); } catch { /* absent is fine */ }
+}
+const { MatchCoordinator } = await import('./cluster/coordinator.js');
+const db = await import('./db/db.js');
+db.initDb();
 let pass = true;
 const check = (n: string, c: boolean, x = '') => { console.log(`${c ? 'PASS' : 'FAIL'}  ${n}  ${x}`); if (!c) pass = false; };
 
@@ -24,7 +29,7 @@ coord.handle(wB, { t: 'queue', sid: 5, cid: 'b', name: 'BOB', fp: null, cursor: 
 const startA = outA.find((m) => m.t === 'matchStart') as Extract<P2W, { t: 'matchStart' }> | undefined;
 const startB = outB.find((m) => m.t === 'matchStart') as Extract<P2W, { t: 'matchStart' }> | undefined;
 check('both players paired across workers', !!startA && !!startB && coord.activeMatches === 1);
-check('roles + opponents correct', startA?.role === 'a' && startB?.role === 'b' && startA?.oppName === 'CHONG' && startB?.oppName === 'BYU',
+check('roles + opponent handles correct', startA?.role === 'a' && startB?.role === 'b' && startA?.oppName === 'BOB' && startB?.oppName === 'ALICE',
   `A opp=${startA?.oppName} B opp=${startB?.oppName}`);
 const mid = startA!.mid;
 
@@ -85,6 +90,64 @@ outA.length = 0; outB.length = 0;
 coord.handle(wB, { t: 'respondChallenge', sid: 10, accept: true });
 check('accepting a cross-worker challenge starts a match',
   !!outA.find((m) => m.t === 'matchStart') && !!outB.find((m) => m.t === 'matchStart') && coord.loungeSize === 0);
+
+// ---- regression: matchEnd can synchronously expose a disconnect back to the
+// coordinator. The completed match must already be detached, so that disconnect
+// cannot turn the KO into a forfeit, write a second result, or apply Elo twice. ----
+{
+  const fpA = 'SHA256:finish-a'; const fpB = 'SHA256:finish-b';
+  db.touchOrCreate(fpA); db.setUsername(fpA, 'FINISHA');
+  db.touchOrCreate(fpB); db.setUsername(fpB, 'FINISHB');
+
+  const c3 = new MatchCoordinator();
+  const endA: P2W[] = [], endB2: P2W[] = [];
+  let detachedBeforeCompletion = false;
+  const w3A: WorkerRef = { id: 11, send: (m) => {
+    endA.push(m);
+    if (m.t === 'matchEnd') {
+      detachedBeforeCompletion = c3.activeMatches === 0;
+      c3.handleExit(11); // the exact finish -> immediate disconnect race
+    }
+  } };
+  const w3B: WorkerRef = { id: 12, send: (m) => endB2.push(m) };
+  c3.handle(w3A, { t: 'queue', sid: 1, cid: 'fa', name: 'FINISHA', fp: fpA, cursor: 10, elo: 1200, region: 'NA' });
+  c3.handle(w3B, { t: 'queue', sid: 1, cid: 'fb', name: 'FINISHB', fp: fpB, cursor: 11, elo: 1200, region: 'NA' });
+  const start = endA.find((m) => m.t === 'matchStart') as Extract<P2W, { t: 'matchStart' }>;
+  const finishing = (c3 as unknown as { matches: Map<string, { match: {
+    a: { hp: number; wins: number }; b: { hp: number; wins: number };
+    phase: string; phaseTimer: number;
+  } }> }).matches.get(start.mid)!;
+
+  for (let i = 0; i < 35; i++) c3.tick(); // make the replay authoritative (>1s)
+  finishing.match.a.wins = 2; finishing.match.a.hp = 73;
+  finishing.match.b.wins = 0; finishing.match.b.hp = 0;
+  finishing.match.phase = 'match-over'; finishing.match.phaseTimer = 0;
+  c3.tick();
+
+  // Further stale completion/disconnect signals remain harmless.
+  c3.handle(w3A, { t: 'leaveMatch', mid: start.mid, sid: 1 });
+  c3.handleExit(12);
+
+  const sql = db.getDb();
+  const history = sql.prepare("SELECT * FROM match_history WHERE winner = 'FINISHA' AND loser = 'FINISHB'").all();
+  const pa = db.getByFingerprint(fpA)!; const pb = db.getByFingerprint(fpB)!;
+  const rich = sql.prepare('SELECT * FROM matches WHERE id = ?').get(start.mid) as {
+    winner: string; a_rounds: number; b_rounds: number; end_reason: string;
+    a_elo_before: number; a_elo_after: number; b_elo_before: number; b_elo_after: number;
+  } | undefined;
+  const koRows = (sql.prepare("SELECT COUNT(*) n FROM match_events WHERE match_id = ? AND type = 'ko'").get(start.mid) as { n: number }).n;
+  const aEnds = endA.filter((m) => m.t === 'matchEnd');
+  const bEnds = endB2.filter((m) => m.t === 'matchEnd');
+
+  check('completed match detached before matchEnd is observable', detachedBeforeCompletion);
+  check('finish -> immediate disconnect writes one result', history.length === 1 && aEnds.length === 1 && bEnds.length === 1,
+    `history=${history.length} aEnds=${aEnds.length} bEnds=${bEnds.length}`);
+  check('one authoritative KO row survives the race', !!rich && rich.winner === 'a' && rich.a_rounds === 2 && rich.b_rounds === 0 && rich.end_reason === 'ko' && koRows === 1,
+    `rich=${JSON.stringify(rich)} koRows=${koRows}`);
+  check('Elo and player records advance exactly once', pa.matches === 1 && pa.wins === 1 && pa.elo === 1216 && pb.matches === 1 && pb.losses === 1 && pb.elo === 1184
+    && rich?.a_elo_before === 1200 && rich.a_elo_after === 1216 && rich.b_elo_before === 1200 && rich.b_elo_after === 1184,
+  `A=${pa.matches}/${pa.elo} B=${pb.matches}/${pb.elo}`);
+}
 
 console.log(pass ? '\nCOORDINATOR TEST: PASS' : '\nCOORDINATOR TEST: FAIL');
 process.exit(pass ? 0 : 1);

--- a/src/recorder-test.ts
+++ b/src/recorder-test.ts
@@ -1,0 +1,85 @@
+// Focused telemetry regressions: each attacker must be charged only for real
+// changes to the opposing fighter's HP, and specials come from the canonical
+// per-character move definitions rather than a legacy hard-coded subset.
+process.env.SF_DB = '/tmp/recorder-test.db';
+import { unlinkSync } from 'fs';
+import { emptyInputs, type Match } from './game/types.js';
+
+for (const suffix of ['', '-wal', '-shm']) {
+  try { unlinkSync(`${process.env.SF_DB}${suffix}`); } catch { /* absent is fine */ }
+}
+const db = await import('./db/db.js');
+const { makeFighter, makeMatch } = await import('./game/engine.js');
+const { specialMovesFor } = await import('./game/moves.js');
+const { MatchRecorder, ENGINE_VERSION } = await import('./telemetry/recorder.js');
+db.initDb();
+
+let pass = true;
+const check = (name: string, ok: boolean, detail = '') => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}  ${detail}`);
+  if (!ok) pass = false;
+};
+const inputs = emptyInputs();
+const recorder = (id: string, m: Match) => new MatchRecorder(id, {
+  mode: 'versus' as const, stage: m.stage, seed: 1, region: 'NA', engineVersion: ENGINE_VERSION,
+  sides: {
+    a: { fp: null, name: 'A', char: m.a.name, isBot: false },
+    b: { fp: null, name: 'B', char: m.b.name, isBot: false },
+  },
+});
+
+const omegaCodex = makeMatch(makeFighter('a', 'OMEGA', 'a'), makeFighter('b', 'CODEX', 'b'));
+const oc = recorder('telemetry-omega-codex', omegaCodex);
+oc.frame(omegaCodex, inputs, inputs); // seed defender HP
+
+omegaCodex.a.attack = specialMovesFor('OMEGA')[0]!.attack;
+omegaCodex.b.attack = specialMovesFor('CODEX')[0]!.attack;
+omegaCodex.b.hp = 91;
+oc.frame(omegaCodex, inputs, inputs); // OMEGA deals 9
+for (let i = 0; i < 3; i++) oc.frame(omegaCodex, inputs, inputs); // unchanged HP: no repeats
+
+omegaCodex.a.hp = 93;
+oc.frame(omegaCodex, inputs, inputs); // CODEX deals 7
+for (let i = 0; i < 3; i++) oc.frame(omegaCodex, inputs, inputs);
+
+omegaCodex.a.attack = 'punch';
+omegaCodex.b.hp = 0;
+oc.frame(omegaCodex, inputs, inputs); // one final hit + one KO
+for (let i = 0; i < 25; i++) oc.frame(omegaCodex, inputs, inputs); // KO state must not repeat
+omegaCodex.a.wins = 2;
+oc.finish(omegaCodex, { winner: 'a', endReason: 'ko' });
+oc.finish(omegaCodex, { winner: 'b', endReason: 'forfeit' }); // finalization is idempotent
+
+const sides = db.getDb().prepare('SELECT * FROM match_players WHERE match_id = ? ORDER BY side').all('telemetry-omega-codex') as Array<{
+  side: string; damage_dealt: number; damage_taken: number; hits: number; specials: number; max_combo: number;
+}>;
+const events = db.getDb().prepare('SELECT type, data_json FROM match_events WHERE match_id = ? ORDER BY id').all('telemetry-omega-codex') as Array<{ type: string; data_json: string }>;
+const koCount = events.filter((e) => e.type === 'ko').length;
+const hitCount = events.filter((e) => e.type === 'hit').length;
+const stored = db.getDb().prepare('SELECT winner, end_reason FROM matches WHERE id = ?').get('telemetry-omega-codex') as { winner: string; end_reason: string };
+check('both attackers use the opposing side previous HP', sides[0]?.damage_dealt === 100 && sides[0]?.damage_taken === 7 && sides[0]?.hits === 2
+  && sides[1]?.damage_dealt === 7 && sides[1]?.damage_taken === 100 && sides[1]?.hits === 1,
+  `sides=${JSON.stringify(sides)}`);
+check('unchanged post-KO frames do not repeat hit/combo/KO accounting', hitCount === 3 && koCount === 1 && sides[0]?.max_combo === 2,
+  `hits=${hitCount} kos=${koCount} combo=${sides[0]?.max_combo}`);
+check('OMEGA and CODEX canonical specials are counted once', sides[0]?.specials === 1 && sides[1]?.specials === 1,
+  `A=${sides[0]?.specials} B=${sides[1]?.specials}`);
+check('a second recorder finish cannot replace the authoritative result', stored.winner === 'a' && stored.end_reason === 'ko', JSON.stringify(stored));
+
+const fableMatch = makeMatch(makeFighter('a', 'FABLE', 'a'), makeFighter('b', 'BYU', 'b'));
+const fable = recorder('telemetry-fable', fableMatch);
+fable.frame(fableMatch, inputs, inputs);
+fableMatch.a.attack = specialMovesFor('FABLE')[0]!.attack;
+fable.frame(fableMatch, inputs, inputs);
+for (let i = 0; i < 30; i++) fable.frame(fableMatch, inputs, inputs);
+fableMatch.a.wins = 2;
+fable.finish(fableMatch, { winner: 'a', endReason: 'ko' });
+const fableSide = db.getDb().prepare("SELECT specials FROM match_players WHERE match_id = ? AND side = 'a'").get('telemetry-fable') as { specials: number };
+const modernKinds = db.getDb().prepare("SELECT data_json FROM match_events WHERE type = 'special' ORDER BY id").all() as Array<{ data_json: string }>;
+const kinds = modernKinds.map((row) => (JSON.parse(row.data_json) as { kind: string }).kind);
+check('FABLE special is recognized from the same canonical move definitions', fableSide.specials === 1 && kinds.includes(specialMovesFor('FABLE')[0]!.attack),
+  `specials=${fableSide.specials} kinds=${kinds.join(',')}`);
+check('modern special events cover OMEGA, CODEX, and FABLE', ['testimony', 'context', 'storyarc'].every((kind) => kinds.includes(kind)), kinds.join(','));
+
+console.log(pass ? '\nRECORDER TEST: PASS' : '\nRECORDER TEST: FAIL');
+process.exit(pass ? 0 : 1);

--- a/src/telemetry/recorder.ts
+++ b/src/telemetry/recorder.ts
@@ -2,13 +2,13 @@
 // box score / event timeline. Fed one call per sim frame (after stepMatch); flushed
 // to the Ringside store at match end. Never throws into the game loop.
 import type { Match, Inputs, Fighter } from '../game/types.js';
+import { specialMoveForAttack } from '../game/moves.js';
 import { captureMatch, captureEvents, captureReplay, type MatchRecord, type MatchEvent, type SideRec } from './store.js';
 
 /** Bumped whenever a sim change would make older replays re-simulate differently.
  *  sf-2: TESTIMONY beam nerf. sf-3: throw mechanic (F) — close-range unblockable grab. */
 export const ENGINE_VERSION = 'sf-5';
 
-const SPECIALS = new Set(['hadouken', 'shoryuken', 'hurricane']);
 const KEYFRAME_EVERY = 300;        // 10s at 30 Hz — seek points for the replayer
 const COMBO_WINDOW = 24;           // frames within which consecutive hits chain
 const MAX_REPLAY_FRAMES = 27000;   // ~15 min cap so an idle practice session can't bloat the BLOB
@@ -41,6 +41,7 @@ export class MatchRecorder {
   private events: MatchEvent[] = [];
   private a = acc(); private b = acc();
   private prev = { aHp: 0, bHp: 0, aAtk: 'none', bAtk: 'none', aWins: 0, bWins: 0, seeded: false };
+  private finished = false;
 
   constructor(public readonly id: string, private readonly meta: RecorderMeta) {}
 
@@ -55,8 +56,8 @@ export class MatchRecorder {
       const p = this.prev;
       if (!p.seeded) { p.aHp = m.a.hp; p.bHp = m.b.hp; p.seeded = true; }
 
-      this.side(m.a, m.b, this.a, this.b, 'a', p.aHp, p.bAtk);   // a's damage to b, a's specials
-      this.side(m.b, m.a, this.b, this.a, 'b', p.bHp, p.aAtk);
+      this.side(m.a, m.b, this.a, this.b, 'a', p.bHp);   // a's damage to b, a's specials
+      this.side(m.b, m.a, this.b, this.a, 'b', p.aHp);
 
       if (m.a.wins > p.aWins || m.b.wins > p.bWins) {
         const w = m.a.wins > p.aWins ? 'a' : 'b';
@@ -70,7 +71,7 @@ export class MatchRecorder {
   }
 
   // Attacker `atk` vs defender `def`; `defPrevHp` is the defender's hp last frame.
-  private side(atk: Fighter, def: Fighter, atkAcc: Acc, defAcc: Acc, who: 'a' | 'b', defPrevHp: number, _prevDefAtk: string): void {
+  private side(atk: Fighter, def: Fighter, atkAcc: Acc, defAcc: Acc, who: 'a' | 'b', defPrevHp: number): void {
     if (def.hp < defPrevHp) {
       const dmg = defPrevHp - def.hp;
       atkAcc.dmgDealt += dmg; defAcc.dmgTaken += dmg; atkAcc.hits++;
@@ -82,7 +83,9 @@ export class MatchRecorder {
     }
     // rising edge into a special = one special performed
     const wasSpecial = who === 'a' ? this.prev.aAtk : this.prev.bAtk;
-    if (SPECIALS.has(atk.attack) && atk.attack !== wasSpecial) {
+    const special = atk.attack === 'none' || atk.attack === 'punch' || atk.attack === 'kick'
+      ? null : specialMoveForAttack(atk.name, atk.attack);
+    if (special && atk.attack !== wasSpecial) {
       atkAcc.specials++;
       this.events.push({ frame: this.f, type: 'special', data: { by: who, kind: atk.attack } });
     }
@@ -97,7 +100,8 @@ export class MatchRecorder {
    *  `opts.winner`/`opts.endReason` override the diff-derived result (used for
    *  forfeits, where round wins don't reflect who actually won). */
   finish(m: Match, opts?: { winner?: 'a' | 'b'; endReason?: string; elo?: { aBefore: number; aAfter: number; bBefore: number; bAfter: number } }): void {
-    if (this.f < 30) return;   // <1s: never really started (early disconnect) — don't store noise
+    if (this.finished || this.f < 30) return;   // <1s: never really started (early disconnect) — don't store noise
+    this.finished = true;
     try {
       const elo = opts?.elo;
       const winner: 'a' | 'b' | 'draw' = opts?.winner ?? (m.a.wins > m.b.wins ? 'a' : m.b.wins > m.a.wins ? 'b' : 'draw');


### PR DESCRIPTION
## Summary

- correct defender-previous-HP accounting on both sides so unchanged and post-KO frames cannot repeat hits, damage, combos, or KOs
- derive special accounting from the canonical move definitions, including OMEGA, CODEX, and FABLE
- detach completed/forfeited matches before persistence notifications can expose disconnects, and make recorder finalization idempotent
- restore player handles in `matchStart.oppName`
- add focused recorder and coordinator regressions to the core suite

Addresses [HAM #1038](https://ham.flobots.xyz/memories/1038) and [HAM #1051](https://ham.flobots.xyz/memories/1051).

Built from deployed main `c5a3ab05451507d0dca61677818df71783a6df2c`.

## Verification

- `pnpm test` passes, including typecheck, focused recorder/coordinator regressions, and the bot lounge integration test
- focused finish/disconnect regression proves one match-history result, one rich KO row, one `matchEnd` per side, and exactly one 1200 -> 1216 / 1200 -> 1184 Elo transition
- `git diff --check` passes

## E2E baseline

The SSH-render E2Es are unavailable in this environment: navigation, social, SSH fight, and practice receive no rendered frames; controls never reaches its menu assertions. I reproduced the same failures from an untouched worktree at exact deployed base `c5a3ab0`, after generating the required ignored host key. No E2E-specific behavior is changed in this PR.