### PR TITLE
Generalize Omega Gym into a portable seeded Agent Gym

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,11 @@ See [the architecture guide](docs/ARCHITECTURE.md) for the render and session pi
 pnpm typecheck
 pnpm test                 # combat, assets, persistence, ANSI reconstruction
 pnpm test:e2e             # lounge, challenge, matchmaking, and practice over real SSH
+pnpm gym --fighter CODEX --seed 42 --matches 20 --json
 pnpm exec tsx src/dump-png.ts fight 112 36
 ```
+
+The deterministic sparring gym accepts any roster fighter and an optional import-safe policy module via `--policy`. Use `--opponents`, `--styles`, and `--matches` to bound a block; `--seed` makes built-in and `Math.random()`-based policies reproducible, while `--json` emits a machine-readable comparison record.
 
 The asset contract verifies all thirteen complete dossiers, all 39 explained special-move definitions, every required fighter pose, and all six stage payloads. CI also rebuilds the authoritative fighter catalog and the Next.js site.
 

--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
     "test:coordinator": "tsx src/coordinator-test.ts",
     "test:bot": "tsx src/bot-server-test.ts",
     "test:newwave": "tsx src/newwave-test.ts",
-    "test": "pnpm typecheck && pnpm test:engine && pnpm test:assets && pnpm test:db && pnpm test:input && pnpm test:render && pnpm test:hud && pnpm test:telemetry && pnpm test:recorder && pnpm test:coordinator && pnpm test:bot && pnpm test:newwave",
+    "test:gym": "tsx src/sparring-gym-test.ts",
+    "test": "pnpm typecheck && pnpm test:engine && pnpm test:assets && pnpm test:db && pnpm test:input && pnpm test:render && pnpm test:hud && pnpm test:telemetry && pnpm test:recorder && pnpm test:coordinator && pnpm test:bot && pnpm test:newwave && pnpm test:gym",
     "test:e2e": "tsx src/navigation-test.ts && tsx src/controls-test.ts && tsx src/social-test.ts && tsx src/ssh-test.ts && tsx src/practice-test.ts",
+    "gym": "tsx src/tools/omega-gym.ts",
     "render-test": "tsx src/render-test.ts",
     "keygen": "mkdir -p keys && if [ ! -f keys/host.key ]; then ssh-keygen -t ed25519 -f keys/host.key -N \"\"; fi"
   },

--- a/src/sparring-gym-test.ts
+++ b/src/sparring-gym-test.ts
@@ -1,0 +1,32 @@
+import { runGym } from './tools/omega-gym.js';
+
+let pass = true;
+const check = (name: string, ok: boolean, detail = '') => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}  ${detail}`);
+  if (!ok) pass = false;
+};
+
+const options = {
+  fighter: 'CODEX',
+  opponents: ['FABLE'],
+  styleNames: ['rushdown', 'turtle'],
+  matches: 2,
+  seed: 73,
+};
+const first = await runGym(options);
+const second = await runGym(options);
+
+check('same seed produces the same complete result', JSON.stringify(first) === JSON.stringify(second));
+check('requested fighter, opponents, and bounded block are preserved',
+  first.fighter === 'CODEX' && first.opponents.join(',') === 'FABLE' && first.total.played === 4,
+  `${first.fighter} vs ${first.opponents.join(',')} played=${first.total.played}`);
+check('style rows contain bounded match and round summaries',
+  first.styles.length === 2 && first.styles.every((row) => row.played === 2 && row.wins + row.losses + row.draws === row.played
+    && row.roundsWon >= 0 && row.roundsLost >= 0));
+
+let rejected = false;
+try { await runGym({ fighter: 'NOT_A_FIGHTER', matches: 1 }); } catch { rejected = true; }
+check('invalid fighters fail fast', rejected);
+
+console.log(pass ? '\nSPARRING GYM TEST: PASS' : '\nSPARRING GYM TEST: FAIL');
+process.exit(pass ? 0 : 1);

--- a/src/tools/omega-gym.ts
+++ b/src/tools/omega-gym.ts
@@ -1,17 +1,15 @@
-// OMEGA sparring gym — runs the REAL bot brain against the REAL engine, headless,
-// over many best-of-3 matches vs a battery of opponent styles. Lets us measure
-// OMEGA's win-rate per style and tune until it dominates every archetype (which
-// is what "always win vs other bots" actually requires — you can't tune blind).
+// Portable sparring gym — runs any import-safe bot policy against the real engine,
+// headless, over deterministic best-of-three blocks and a battery of opponent
+// styles. The built-in champion policy makes the tool runnable from a clean clone.
 //
-// Run:  npx tsx src/tools/omega-gym.ts [matchesPerStyle]
+// Run: pnpm gym --fighter CODEX --seed 42 --matches 20 --json
 import { makeFighter, makeMatch, stepMatch, attackActive, specialMoveStats } from '../game/engine.js';
 import { emptyInputs } from '../game/types.js';
 import type { Fighter, Inputs, Match } from '../game/types.js';
 import type { SpecialAttack } from '../game/moves.js';
-// The bot module is import-safe (only connects when run as main) and exports its brain.
-// It lives outside the repo (deployed bot), so it carries no type declarations.
-// @ts-expect-error -- external .mjs bot module, no types
-import { decide as omegaDecide, resetModel as omegaReset } from '/home/ubuntu/omega-bot/omega-bot.mjs';
+import { ROSTER } from '../game/roster.js';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 const SPECIAL_KINDS = new Set(['hadouken', 'shoryuken', 'hurricane', 'rolling', 'verticalroll', 'electric', 'testimony', 'nullstep', 'entropy', 'context', 'branchwalk', 'mergecomet', 'storyarc', 'plottwist', 'inktempest']);
 
@@ -33,7 +31,9 @@ function toInputs(cmd: any): Inputs {
   return i;
 }
 
-type Policy = (self: any, opp: any, phase: string) => any;
+export type GymPolicy = (self: any, opp: any, phase: string, projectiles?: any[], role?: 'a' | 'b') => any;
+type Policy = GymPolicy;
+interface LoadedPolicy { decide: GymPolicy; reset?: () => void; label: string; }
 const RNG = () => Math.random();
 const specCode = (self: any, kind: 'beam' | 'well' | 'warp' | 'up' | 'back') => {
   const f = self.facing;
@@ -152,9 +152,9 @@ const styles: Record<string, Policy> = {
   },
 };
 
-function playMatch(oppPolicy: Policy, oppChar: string): { won: boolean; aWins: number; bWins: number; margin: number } {
-  omegaReset();
-  const a = makeFighter('a', 'OMEGA', 'a');
+function playMatch(target: LoadedPolicy, oppPolicy: Policy, fighter: string, oppChar: string): { outcome: 'win' | 'loss' | 'draw'; aWins: number; bWins: number; margin: number } {
+  target.reset?.();
+  const a = makeFighter('a', fighter, 'a');
   const b = makeFighter('b', oppChar, 'b');
   const m: Match = makeMatch(a, b);
   let frames = 0;
@@ -162,31 +162,149 @@ function playMatch(oppPolicy: Policy, oppChar: string): { won: boolean; aWins: n
   while (m.phase !== 'match-over' && frames < CAP) {
     const proj = m.projectiles.filter((p) => p.active).map((p) => ({ owner: p.owner, x: Math.round(p.x), y: Math.round(p.y), vx: p.vx, style: p.style }));
     let cmdA: any = {};
-    try { cmdA = omegaDecide(view(m.a), view(m.b), m.phase, proj, 'a') || {}; } catch { cmdA = {}; }
+    try { cmdA = target.decide(view(m.a), view(m.b), m.phase, proj, 'a') || {}; } catch { cmdA = {}; }
     let cmdB: any = {};
     try { cmdB = oppPolicy(view(m.b), view(m.a), m.phase) || {}; } catch { cmdB = {}; }
     stepMatch(m, toInputs(cmdA), toInputs(cmdB));
     frames++;
   }
-  return { won: m.a.wins > m.b.wins, aWins: m.a.wins, bWins: m.b.wins, margin: m.a.hp - m.b.hp };
+  const outcome = m.phase !== 'match-over' || m.a.wins === m.b.wins ? 'draw' : m.a.wins > m.b.wins ? 'win' : 'loss';
+  return { outcome, aWins: m.a.wins, bWins: m.b.wins, margin: m.a.hp - m.b.hp };
 }
 
-const N = parseInt(process.argv[2] ?? '40', 10);
-const OPP_CHARS = ['FABLE', 'CODEX', 'BYU', 'ZANG'];
-console.log(`OMEGA GYM — ${N} matches per style (opponent chars cycled: ${OPP_CHARS.join(', ')})\n`);
-let totalW = 0, totalG = 0;
-const rows: string[] = [];
-for (const [name, pol] of Object.entries(styles)) {
-  let w = 0, roundsW = 0, roundsL = 0;
-  for (let i = 0; i < N; i++) {
-    const r = playMatch(pol, OPP_CHARS[i % OPP_CHARS.length]!);
-    if (r.won) w++;
-    roundsW += r.aWins; roundsL += r.bWins;
-  }
-  totalW += w; totalG += N;
-  const pct = ((w / N) * 100).toFixed(0);
-  rows.push(`${name.padEnd(9)} ${String(w).padStart(3)}/${N}  (${pct}%)   rounds ${roundsW}-${roundsL}`);
+export interface GymOptions {
+  fighter?: string;
+  opponents?: string[];
+  styleNames?: string[];
+  matches?: number;
+  seed?: number;
+  policyPath?: string;
 }
-console.log('style      win/played  winrate   rounds');
-for (const r of rows) console.log(r);
-console.log(`\nOVERALL: ${totalW}/${totalG} = ${((totalW / totalG) * 100).toFixed(1)}%`);
+
+export interface GymResult {
+  fighter: string;
+  policy: string;
+  opponents: string[];
+  seed: number;
+  matchesPerStyle: number;
+  styles: Array<{ name: string; wins: number; losses: number; draws: number; played: number; winRate: number; roundsWon: number; roundsLost: number }>;
+  total: { wins: number; losses: number; draws: number; played: number; winRate: number };
+}
+
+function seededRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state += 0x6D2B79F5;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function knownFighter(name: string): string {
+  const upper = name.toUpperCase();
+  if (!ROSTER.some((fighter) => fighter.name === upper)) throw new Error(`unknown fighter: ${name}`);
+  return upper;
+}
+
+async function loadPolicy(policyPath?: string): Promise<LoadedPolicy> {
+  if (!policyPath) return { decide: styles.champion!, label: 'builtin:champion' };
+  const absolute = resolve(policyPath);
+  const mod = await import(pathToFileURL(absolute).href) as { decide?: GymPolicy; reset?: () => void; resetModel?: () => void };
+  if (typeof mod.decide !== 'function') throw new Error(`policy must export decide(): ${absolute}`);
+  return { decide: mod.decide, reset: mod.reset ?? mod.resetModel, label: absolute };
+}
+
+export async function runGym(options: GymOptions = {}): Promise<GymResult> {
+  const fighter = knownFighter(options.fighter ?? 'OMEGA');
+  const opponents = (options.opponents?.length ? options.opponents : ['FABLE', 'CODEX', 'BYU', 'ZANG']).map(knownFighter);
+  const styleNames = options.styleNames?.length ? options.styleNames : Object.keys(styles);
+  for (const name of styleNames) if (!styles[name]) throw new Error(`unknown style: ${name}`);
+  const matches = options.matches ?? 40;
+  if (!Number.isInteger(matches) || matches < 1 || matches > 1000) throw new Error('--matches must be an integer from 1 to 1000');
+  const seed = options.seed ?? 1;
+  if (!Number.isInteger(seed)) throw new Error('--seed must be an integer');
+  const target = await loadPolicy(options.policyPath);
+
+  const originalRandom = Math.random;
+  Math.random = seededRandom(seed);
+  try {
+    let totalWins = 0, totalLosses = 0, totalDraws = 0;
+    const rows: GymResult['styles'] = [];
+    for (const name of styleNames) {
+      const policy = styles[name]!;
+      let wins = 0, losses = 0, draws = 0, roundsWon = 0, roundsLost = 0;
+      for (let i = 0; i < matches; i++) {
+        const result = playMatch(target, policy, fighter, opponents[i % opponents.length]!);
+        if (result.outcome === 'win') wins++;
+        else if (result.outcome === 'loss') losses++;
+        else draws++;
+        roundsWon += result.aWins;
+        roundsLost += result.bWins;
+      }
+      totalWins += wins; totalLosses += losses; totalDraws += draws;
+      rows.push({ name, wins, losses, draws, played: matches, winRate: wins / matches, roundsWon, roundsLost });
+    }
+    const totalPlayed = matches * rows.length;
+    return {
+      fighter, policy: target.label, opponents, seed, matchesPerStyle: matches, styles: rows,
+      total: { wins: totalWins, losses: totalLosses, draws: totalDraws, played: totalPlayed, winRate: totalPlayed ? totalWins / totalPlayed : 0 },
+    };
+  } finally {
+    Math.random = originalRandom;
+  }
+}
+
+function parseArgs(argv: string[]): { options: GymOptions; json: boolean; help: boolean } {
+  const values: Record<string, string> = {};
+  let json = false, help = false;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    if (arg === '--json') { json = true; continue; }
+    if (arg === '--help' || arg === '-h') { help = true; continue; }
+    if (!arg.startsWith('--')) {
+      if (!values.matches) values.matches = arg;
+      else throw new Error(`unexpected argument: ${arg}`);
+      continue;
+    }
+    const name = arg.slice(2);
+    const value = argv[++i];
+    if (!value || value.startsWith('--')) throw new Error(`${arg} requires a value`);
+    values[name] = value;
+  }
+  return {
+    json, help,
+    options: {
+      fighter: values.fighter,
+      opponents: values.opponents?.split(',').filter(Boolean),
+      styleNames: values.styles?.split(',').filter(Boolean),
+      matches: values.matches ? Number(values.matches) : undefined,
+      seed: values.seed ? Number(values.seed) : undefined,
+      policyPath: values.policy,
+    },
+  };
+}
+
+function printHuman(result: GymResult): void {
+  console.log(`${result.fighter} SPARRING GYM — seed ${result.seed}, ${result.matchesPerStyle} matches per style`);
+  console.log(`policy: ${result.policy}`);
+  console.log(`opponents: ${result.opponents.join(', ')}\n`);
+  console.log('style      W-L-D       winrate   rounds');
+  for (const row of result.styles) {
+    const pct = `${(row.winRate * 100).toFixed(0)}%`;
+    console.log(`${row.name.padEnd(9)} ${row.wins}-${row.losses}-${row.draws}`.padEnd(22) + `(${pct.padStart(4)})   rounds ${row.roundsWon}-${row.roundsLost}`);
+  }
+  console.log(`\nOVERALL: ${result.total.wins}-${result.total.losses}-${result.total.draws} over ${result.total.played} = ${(result.total.winRate * 100).toFixed(1)}% wins`);
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : '';
+if (import.meta.url === invokedPath) {
+  const parsed = parseArgs(process.argv.slice(2));
+  if (parsed.help) {
+    console.log(`Usage: pnpm gym [matches] [options]\n\nOptions:\n  --fighter NAME       fighter controlled by the target policy (default OMEGA)\n  --opponents A,B,...  opponent characters to cycle\n  --styles A,B,...     opponent archetypes to run\n  --matches N          matches per style (1-1000)\n  --seed N             deterministic random seed (default 1)\n  --policy PATH        module exporting decide() and optional reset()/resetModel()\n  --json               emit machine-readable JSON\n  --help               show this help`);
+  } else {
+    const result = await runGym(parsed.options);
+    if (parsed.json) console.log(JSON.stringify(result)); else printHuman(result);
+  }
+}


### PR DESCRIPTION
## What
- remove the machine-specific Omega policy import
- run any roster fighter against configurable characters and opponent styles
- load an optional import-safe decide policy with reset/resetModel support
- add deterministic seeding, bounded match counts, draw reporting, and JSON output
- add a documented pnpm gym command and deterministic regression coverage

## Why
The existing gym depended on an absolute path on one host and could only evaluate Omega. This makes the offline sparring loop reproducible from a clean clone and useful to every agent character.

## Impact
The built-in champion policy remains the no-setup default. No SSH identity, live server, or credentials are involved.

## Verification
- pnpm test
- pnpm test:gym
- pnpm gym --fighter CODEX --opponents FABLE --styles rushdown,turtle --matches 1 --seed 73 --json
- git diff --check