### PR TITLE
Expand telemetry and finalization regression coverage

### DIFF
--- a/src/coordinator-test.ts
+++ b/src/coordinator-test.ts
@@ -149,5 +149,60 @@ check('accepting a cross-worker challenge starts a match',
   `A=${pa.matches}/${pa.elo} B=${pb.matches}/${pb.elo}`);
 }
 
+// Symmetric race: side B wins, while side A synchronously sends leaveMatch from
+// its matchEnd callback. This covers the loser-side and explicit leave path in
+// addition to the winner-side worker-exit path above.
+{
+  const fpA = 'SHA256:finish-race-a'; const fpB = 'SHA256:finish-race-b';
+  db.touchOrCreate(fpA); db.setUsername(fpA, 'RACEA');
+  db.touchOrCreate(fpB); db.setUsername(fpB, 'RACEB');
+
+  const c4 = new MatchCoordinator();
+  const endA: P2W[] = [], endB3: P2W[] = [];
+  let mid = '';
+  let detachedBeforeLoserLeave = false;
+  const w4A: WorkerRef = { id: 21, send: (m) => {
+    endA.push(m);
+    if (m.t === 'matchStart') mid = m.mid;
+    if (m.t === 'matchEnd') {
+      detachedBeforeLoserLeave = c4.activeMatches === 0;
+      c4.handle(w4A, { t: 'leaveMatch', mid, sid: 1 });
+    }
+  } };
+  const w4B: WorkerRef = { id: 22, send: (m) => endB3.push(m) };
+  c4.handle(w4A, { t: 'queue', sid: 1, cid: 'ra', name: 'RACEA', fp: fpA, cursor: 10, elo: 1200, region: 'NA' });
+  c4.handle(w4B, { t: 'queue', sid: 1, cid: 'rb', name: 'RACEB', fp: fpB, cursor: 11, elo: 1200, region: 'NA' });
+  const finishing = (c4 as unknown as { matches: Map<string, { match: {
+    a: { hp: number; wins: number }; b: { hp: number; wins: number };
+    phase: string; phaseTimer: number;
+  } }> }).matches.get(mid)!;
+
+  for (let i = 0; i < 35; i++) c4.tick();
+  finishing.match.a.wins = 0; finishing.match.a.hp = 0;
+  finishing.match.b.wins = 2; finishing.match.b.hp = 61;
+  finishing.match.phase = 'match-over'; finishing.match.phaseTimer = 0;
+  c4.tick();
+  c4.handleExit(21); c4.handleExit(22); // stale worker exits are also harmless
+
+  const sql = db.getDb();
+  const history = sql.prepare("SELECT * FROM match_history WHERE winner = 'RACEB' AND loser = 'RACEA'").all();
+  const pa = db.getByFingerprint(fpA)!; const pb = db.getByFingerprint(fpB)!;
+  const rich = sql.prepare('SELECT * FROM matches WHERE id = ?').get(mid) as {
+    winner: string; a_rounds: number; b_rounds: number; end_reason: string;
+    a_elo_before: number; a_elo_after: number; b_elo_before: number; b_elo_after: number;
+  } | undefined;
+  const aEnds = endA.filter((m) => m.t === 'matchEnd');
+  const bEnds = endB3.filter((m) => m.t === 'matchEnd');
+
+  check('completed match detached before loser leaveMatch is observable', detachedBeforeLoserLeave);
+  check('B-side KO plus synchronous loser leave writes one result', history.length === 1 && aEnds.length === 1 && bEnds.length === 1,
+    `history=${history.length} aEnds=${aEnds.length} bEnds=${bEnds.length}`);
+  check('B-side result and rounds survive the leave race', !!rich && rich.winner === 'b' && rich.a_rounds === 0 && rich.b_rounds === 2 && rich.end_reason === 'ko',
+    `rich=${JSON.stringify(rich)}`);
+  check('symmetric Elo and records advance exactly once', pa.matches === 1 && pa.losses === 1 && pa.elo === 1184 && pb.matches === 1 && pb.wins === 1 && pb.elo === 1216
+    && rich?.a_elo_before === 1200 && rich.a_elo_after === 1184 && rich.b_elo_before === 1200 && rich.b_elo_after === 1216,
+  `A=${pa.matches}/${pa.elo} B=${pb.matches}/${pb.elo}`);
+}
+
 console.log(pass ? '\nCOORDINATOR TEST: PASS' : '\nCOORDINATOR TEST: FAIL');
 process.exit(pass ? 0 : 1);

--- a/src/recorder-test.ts
+++ b/src/recorder-test.ts
@@ -66,20 +66,31 @@ check('OMEGA and CODEX canonical specials are counted once', sides[0]?.specials 
   `A=${sides[0]?.specials} B=${sides[1]?.specials}`);
 check('a second recorder finish cannot replace the authoritative result', stored.winner === 'a' && stored.end_reason === 'ko', JSON.stringify(stored));
 
-const fableMatch = makeMatch(makeFighter('a', 'FABLE', 'a'), makeFighter('b', 'BYU', 'b'));
-const fable = recorder('telemetry-fable', fableMatch);
-fable.frame(fableMatch, inputs, inputs);
-fableMatch.a.attack = specialMovesFor('FABLE')[0]!.attack;
-fable.frame(fableMatch, inputs, inputs);
-for (let i = 0; i < 30; i++) fable.frame(fableMatch, inputs, inputs);
-fableMatch.a.wins = 2;
-fable.finish(fableMatch, { winner: 'a', endReason: 'ko' });
-const fableSide = db.getDb().prepare("SELECT specials FROM match_players WHERE match_id = ? AND side = 'a'").get('telemetry-fable') as { specials: number };
-const modernKinds = db.getDb().prepare("SELECT data_json FROM match_events WHERE type = 'special' ORDER BY id").all() as Array<{ data_json: string }>;
-const kinds = modernKinds.map((row) => (JSON.parse(row.data_json) as { kind: string }).kind);
-check('FABLE special is recognized from the same canonical move definitions', fableSide.specials === 1 && kinds.includes(specialMovesFor('FABLE')[0]!.attack),
-  `specials=${fableSide.specials} kinds=${kinds.join(',')}`);
-check('modern special events cover OMEGA, CODEX, and FABLE', ['testimony', 'context', 'storyarc'].every((kind) => kinds.includes(kind)), kinds.join(','));
+// Exercise every modern move rather than one representative per character. A
+// neutral frame separates each attack so the recorder sees three distinct
+// rising edges and stores the exact canonical attack kinds.
+for (const character of ['OMEGA', 'CODEX', 'FABLE'] as const) {
+  const match = makeMatch(makeFighter('a', character, 'a'), makeFighter('b', 'BYU', 'b'));
+  const id = `telemetry-all-specials-${character.toLowerCase()}`;
+  const modern = recorder(id, match);
+  modern.frame(match, inputs, inputs);
+  const expected = specialMovesFor(character).map((move) => move.attack);
+  for (const attack of expected) {
+    match.a.attack = attack;
+    modern.frame(match, inputs, inputs);
+    match.a.attack = 'none';
+    modern.frame(match, inputs, inputs);
+  }
+  for (let i = 0; i < 25; i++) modern.frame(match, inputs, inputs);
+  match.a.wins = 2;
+  modern.finish(match, { winner: 'a', endReason: 'ko' });
+
+  const side = db.getDb().prepare("SELECT specials FROM match_players WHERE match_id = ? AND side = 'a'").get(id) as { specials: number };
+  const rows = db.getDb().prepare("SELECT data_json FROM match_events WHERE match_id = ? AND type = 'special' ORDER BY id").all(id) as Array<{ data_json: string }>;
+  const actual = rows.map((row) => (JSON.parse(row.data_json) as { kind: string }).kind);
+  check(`${character} counts all canonical specials exactly once`, side.specials === expected.length && JSON.stringify(actual) === JSON.stringify(expected),
+    `specials=${side.specials} kinds=${actual.join(',')}`);
+}
 
 console.log(pass ? '\nRECORDER TEST: PASS' : '\nRECORDER TEST: FAIL');
 process.exit(pass ? 0 : 1);


### PR DESCRIPTION
## What
- table-drive exact canonical special counting for all nine OMEGA, CODEX, and FABLE moves
- add the symmetric side-B KO race with synchronous loser leaveMatch
- verify one authoritative result, one matchEnd per side, stable rounds/end reason, and single Elo application

## Why
The initial telemetry fix covered one modern special per character and one winner-side worker-exit ordering. This closes the remaining move and finalization symmetry gaps.

## Impact
Test-only changes. Runtime behavior is unchanged.

## Verification
- pnpm test
- pnpm test:recorder
- pnpm test:coordinator
- git diff --check