### PR TITLE
fix: label new-wave specials canonically in Agent Gym

### DIFF
--- a/src/sparring-gym-test.ts
+++ b/src/sparring-gym-test.ts
@@ -1,4 +1,5 @@
-import { runGym } from './tools/omega-gym.js';
+import { makeFighter } from './game/engine.js';
+import { gymFighterView, runGym } from './tools/omega-gym.js';
 
 let pass = true;
 const check = (name: string, ok: boolean, detail = '') => {
@@ -27,6 +28,14 @@ check('style rows contain bounded match and round summaries',
 let rejected = false;
 try { await runGym({ fighter: 'NOT_A_FIGHTER', matches: 1 }); } catch { rejected = true; }
 check('invalid fighters fail fast', rejected);
+
+for (const [character, attack] of [['MNEME', 'construct'], ['AJAX', 'boomerang'], ['XENON', 'phase']] as const) {
+  const fighter = makeFighter('a', character, 'a');
+  fighter.attack = attack;
+  const observed = gymFighterView(fighter);
+  check(`${character} canonical special is labeled in agent observations`, observed.special === true,
+    `attack=${observed.attack} special=${observed.special}`);
+}
 
 console.log(pass ? '\nSPARRING GYM TEST: PASS' : '\nSPARRING GYM TEST: FAIL');
 process.exit(pass ? 0 : 1);

--- a/src/tools/omega-gym.ts
+++ b/src/tools/omega-gym.ts
@@ -6,16 +6,15 @@
 import { makeFighter, makeMatch, stepMatch, attackActive, specialMoveStats } from '../game/engine.js';
 import { emptyInputs } from '../game/types.js';
 import type { Fighter, Inputs, Match } from '../game/types.js';
-import type { SpecialAttack } from '../game/moves.js';
+import { specialMoveForAttack, type SpecialAttack } from '../game/moves.js';
 import { ROSTER } from '../game/roster.js';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-const SPECIAL_KINDS = new Set(['hadouken', 'shoryuken', 'hurricane', 'rolling', 'verticalroll', 'electric', 'testimony', 'nullstep', 'entropy', 'context', 'branchwalk', 'mergecomet', 'storyarc', 'plottwist', 'inktempest']);
-
 // Build the exact per-tick view a bot receives over the wire (mirrors bot-server fighterView).
-function view(f: Fighter): any {
-  const special = SPECIAL_KINDS.has(f.attack);
+export function gymFighterView(f: Fighter): any {
+  const special = f.attack !== 'none' && f.attack !== 'punch' && f.attack !== 'kick' && f.attack !== 'throw'
+    && specialMoveForAttack(f.name, f.attack as SpecialAttack) !== null;
   const active = attackActive(f);
   let casting = false;
   if (special && !active) { try { casting = f.attackFrame < specialMoveStats(f.attack as SpecialAttack).startup; } catch { /* ignore */ } }
@@ -23,7 +22,7 @@ function view(f: Fighter): any {
     facing: f.facing, hp: f.hp, wins: f.wins, attack: f.attack, attackFrame: f.attackFrame,
     stun: f.stun, pose: f.pose, crouching: f.crouching, special, active, casting };
 }
-function toInputs(cmd: any): Inputs {
+export function gymInputs(cmd: any): Inputs {
   const i = emptyInputs();
   if (cmd?.moveX) i.moveX = cmd.moveX;
   i.jump = !!cmd?.jump; i.punch = !!cmd?.punch; i.kick = !!cmd?.kick; i.throw = !!cmd?.throw; i.down = !!cmd?.down;
@@ -162,10 +161,10 @@ function playMatch(target: LoadedPolicy, oppPolicy: Policy, fighter: string, opp
   while (m.phase !== 'match-over' && frames < CAP) {
     const proj = m.projectiles.filter((p) => p.active).map((p) => ({ owner: p.owner, x: Math.round(p.x), y: Math.round(p.y), vx: p.vx, style: p.style }));
     let cmdA: any = {};
-    try { cmdA = target.decide(view(m.a), view(m.b), m.phase, proj, 'a') || {}; } catch { cmdA = {}; }
+    try { cmdA = target.decide(gymFighterView(m.a), gymFighterView(m.b), m.phase, proj, 'a') || {}; } catch { cmdA = {}; }
     let cmdB: any = {};
-    try { cmdB = oppPolicy(view(m.b), view(m.a), m.phase) || {}; } catch { cmdB = {}; }
-    stepMatch(m, toInputs(cmdA), toInputs(cmdB));
+    try { cmdB = oppPolicy(gymFighterView(m.b), gymFighterView(m.a), m.phase) || {}; } catch { cmdB = {}; }
+    stepMatch(m, gymInputs(cmdA), gymInputs(cmdB));
     frames++;
   }
   const outcome = m.phase !== 'match-over' || m.a.wins === m.b.wins ? 'draw' : m.a.wins > m.b.wins ? 'win' : 'loss';


### PR DESCRIPTION
## What changed

- Replaces Agent Gym's stale hard-coded special list with the canonical `specialMoveForAttack(character, attack)` resolver.
- Exports the observation and input adapters for reuse by offline environment wrappers.
- Adds regressions for MNEME TURRET, AJAX BOOMERANG, and XENON PHASE DASH observations.

## Why

The Agent Gym predated the new-wave fighters. Their canonical special attacks could be active in the real engine while the gym labeled them `special=false`, which also made casting observations unreliable for policies and generated datasets.

## Impact

MNEME, AJAX, and XENON now receive the same canonical special classification in Agent Gym that the game engine uses. Existing fighters and policy behavior are unchanged.

## Validation

- `pnpm test`
- Focused seeded Agent Gym determinism and new-wave observation regressions
