### PR TITLE
feat: add provenance-safe CODEX live match logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
     "test:bot": "tsx src/bot-server-test.ts",
     "test:newwave": "tsx src/newwave-test.ts",
     "test:gym": "tsx src/sparring-gym-test.ts",
+    "test:codex-logger": "tsx src/codex-live-logger-test.ts",
     "test:example-bot": "node examples/bot-test.mjs",
-    "test": "pnpm typecheck && pnpm test:engine && pnpm test:assets && pnpm test:db && pnpm test:input && pnpm test:render && pnpm test:hud && pnpm test:telemetry && pnpm test:recorder && pnpm test:coordinator && pnpm test:bot && pnpm test:newwave && pnpm test:gym && pnpm test:example-bot",
+    "test": "pnpm typecheck && pnpm test:engine && pnpm test:assets && pnpm test:db && pnpm test:input && pnpm test:render && pnpm test:hud && pnpm test:telemetry && pnpm test:recorder && pnpm test:coordinator && pnpm test:bot && pnpm test:newwave && pnpm test:gym && pnpm test:codex-logger && pnpm test:example-bot",
     "test:e2e": "tsx src/navigation-test.ts && tsx src/social-test.ts && tsx src/ssh-test.ts && tsx src/practice-test.ts",
     "gym": "tsx src/tools/omega-gym.ts",
+    "bot:codex-logged": "tsx src/tools/codex-live-logger.ts",
     "render-test": "tsx src/render-test.ts",
     "keygen": "mkdir -p keys && if [ ! -f keys/host.key ]; then ssh-keygen -t ed25519 -f keys/host.key -N \"\"; fi"
   },

--- a/src/bot/adaptive-codex-policy.ts
+++ b/src/bot/adaptive-codex-policy.ts
@@ -1,0 +1,293 @@
+import {
+  ATTACKS,
+  THROW,
+  attackActive,
+  specialMoveStats,
+} from '../game/engine.js';
+import {
+  specialMoveForAttack,
+  specialMoveMotionCode,
+  type SpecialAttack,
+} from '../game/moves.js';
+import { emptyInputs, type AttackKind, type Fighter, type Inputs, type MatchPhase } from '../game/types.js';
+
+export interface FighterObservation {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  facing: 1 | -1;
+  hp: number;
+  wins: number;
+  attack: AttackKind;
+  attackFrame: number;
+  stun: number;
+  crouching: boolean;
+  special?: boolean;
+  active?: boolean;
+  casting?: boolean;
+}
+
+export interface ProjectileObservation {
+  owner?: 'a' | 'b';
+  x: number;
+  y: number;
+  vx: number;
+}
+
+export interface CombatObservation {
+  frame: number;
+  phase: MatchPhase;
+  round: number;
+  roundTime: number;
+  you: FighterObservation;
+  opp: FighterObservation;
+  projectiles: readonly ProjectileObservation[];
+}
+
+export interface AdaptivePolicyConfig {
+  targetSpacing: number;
+  contextClosingDistance: number;
+  contextCooldown: number;
+  evidenceLeadFrames: number;
+  evidenceMaxDistance: number;
+  branchwalkMinRecovery: number;
+  pokeWhenBehind: boolean;
+}
+
+export const DEFAULT_ADAPTIVE_CONFIG: AdaptivePolicyConfig = {
+  // Selected for FABLE conversion on sf-5, with overall and worst-matchup
+  // performance as guardrails, then confirmed on disjoint mirrored holdouts.
+  targetSpacing: 34,
+  contextClosingDistance: 50,
+  contextCooldown: 46,
+  evidenceLeadFrames: 4,
+  evidenceMaxDistance: 34,
+  branchwalkMinRecovery: 0,
+  pokeWhenBehind: true,
+};
+
+const SPECIAL_ATTACKS = new Set<AttackKind>([
+  'hadouken', 'shoryuken', 'hurricane', 'electric', 'rolling', 'verticalroll',
+  'testimony', 'nullstep', 'entropy', 'context', 'branchwalk', 'mergecomet',
+  'storyarc', 'plottwist', 'inktempest', 'construct', 'nova', 'volley',
+  'boomerang', 'armor', 'lasso', 'phase', 'reflect', 'blink',
+]);
+
+const CONTEXT_REACTIONS = new Set<AttackKind>([
+  'hadouken', 'testimony', 'rolling', 'electric', 'inktempest', 'plottwist',
+]);
+
+interface AttackPhase {
+  active: boolean;
+  casting: boolean;
+  recovering: boolean;
+  remaining: number;
+}
+
+function timing(attack: AttackKind): { startup: number; active: number; total: number } {
+  if (attack === 'none') return { startup: 0, active: 0, total: 0 };
+  if (attack === 'punch' || attack === 'kick') {
+    const spec = ATTACKS[attack];
+    return { startup: spec.startup, active: spec.active, total: spec.startup + spec.active + spec.recovery };
+  }
+  if (attack === 'throw') return { startup: THROW.startup, active: THROW.active, total: THROW.total };
+  const stats = specialMoveStats(attack as SpecialAttack);
+  return { startup: stats.startup, active: stats.active, total: stats.startup + stats.active + stats.recovery };
+}
+
+function phaseOf(fighter: FighterObservation): AttackPhase {
+  if (fighter.attack === 'none') return { active: false, casting: false, recovering: false, remaining: 0 };
+  const frames = timing(fighter.attack);
+  const active = fighter.active ?? (
+    fighter.attackFrame >= frames.startup && fighter.attackFrame < frames.startup + frames.active
+  );
+  const casting = fighter.casting ?? (
+    SPECIAL_ATTACKS.has(fighter.attack) && fighter.attackFrame < frames.startup
+  );
+  return {
+    active,
+    casting,
+    recovering: !active && !casting && fighter.attackFrame >= frames.startup + frames.active,
+    remaining: Math.max(0, frames.total - fighter.attackFrame),
+  };
+}
+
+function relativeSpecial(character: string, attack: AttackKind, facing: 1 | -1): Inputs | null {
+  if (!SPECIAL_ATTACKS.has(attack)) return null;
+  const move = specialMoveForAttack(character, attack as SpecialAttack);
+  if (!move) return null;
+  const input = emptyInputs();
+  input.motion = specialMoveMotionCode(move, facing);
+  input[move.button] = true;
+  return input;
+}
+
+export function observationFromFighters(
+  frame: number,
+  phase: MatchPhase,
+  round: number,
+  roundTime: number,
+  you: Fighter,
+  opp: Fighter,
+  projectiles: readonly ProjectileObservation[],
+): CombatObservation {
+  const view = (fighter: Fighter): FighterObservation => ({
+    x: fighter.x,
+    y: fighter.y,
+    vx: fighter.vx,
+    vy: fighter.vy,
+    facing: fighter.facing,
+    hp: fighter.hp,
+    wins: fighter.wins,
+    attack: fighter.attack,
+    attackFrame: fighter.attackFrame,
+    stun: fighter.stun,
+    crouching: fighter.crouching,
+    special: SPECIAL_ATTACKS.has(fighter.attack),
+    active: attackActive(fighter),
+    casting: SPECIAL_ATTACKS.has(fighter.attack) && fighter.attackFrame < timing(fighter.attack).startup,
+  });
+  return { frame, phase, round, roundTime, you: view(you), opp: view(opp), projectiles };
+}
+
+export class AdaptiveCodexPolicy {
+  readonly actions = new Map<string, number>();
+  private lastActionFrame = -999;
+  private lastContextFrame = -999;
+  private lastPokeFrame = -999;
+  private lastFrame = -1;
+
+  constructor(readonly config: AdaptivePolicyConfig = DEFAULT_ADAPTIVE_CONFIG) {}
+
+  reset(): void {
+    this.actions.clear();
+    this.lastActionFrame = -999;
+    this.lastContextFrame = -999;
+    this.lastPokeFrame = -999;
+    this.lastFrame = -1;
+  }
+
+  decide(state: CombatObservation): Inputs {
+    if (state.frame < this.lastFrame) this.reset();
+    this.lastFrame = state.frame;
+    const input = emptyInputs();
+    if (state.phase !== 'fight') return input;
+
+    const { you, opp } = state;
+    const dx = opp.x - you.x;
+    const distance = Math.abs(dx);
+    const toward = Math.sign(dx) || you.facing;
+    const away = -toward;
+    const grounded = you.y <= 0.5 && you.vy <= 0;
+    const free = you.attack === 'none' && you.stun <= 0;
+    const ahead = you.hp > opp.hp + 4;
+    const opponentPhase = phaseOf(opp);
+    const opponentClosing = Math.abs(opp.vx) > 0.2 && Math.sign(you.x - opp.x) === Math.sign(opp.vx);
+    const incoming = state.projectiles.some((projectile) =>
+      Math.abs(projectile.x - you.x) < 82 &&
+      Math.sign(you.x - projectile.x) === Math.sign(projectile.vx)
+    );
+    const ready = state.frame - this.lastActionFrame > 7;
+
+    const record = (name: string): void => {
+      this.actions.set(name, (this.actions.get(name) ?? 0) + 1);
+    };
+    const special = (attack: AttackKind): Inputs | null => {
+      const result = relativeSpecial('CODEX', attack, you.facing);
+      if (!result) return null;
+      this.lastActionFrame = state.frame;
+      if (attack === 'context') this.lastContextFrame = state.frame;
+      record(attack);
+      return result;
+    };
+
+    // Weight of Evidence is a conversion, not a default landing animation. Predict
+    // the opponent's short-term lane and commit only while they are already busy.
+    if (you.attack === 'context' && you.vy < 0 && you.y > 14) {
+      const projectedDx = dx + (opp.vx - you.vx) * this.config.evidenceLeadFrames;
+      if (
+        projectedDx * you.facing > 0 &&
+        Math.abs(projectedDx) <= this.config.evidenceMaxDistance &&
+        (opponentPhase.active || opponentPhase.recovering || opp.stun > 0)
+      ) return special('mergecomet') ?? input;
+    }
+
+    if (!free) return input;
+
+    // Block live hitboxes before selecting an offensive rollout.
+    if (opponentPhase.active && distance < 68 && grounded) {
+      input.moveX = away;
+      record('guard');
+      return input;
+    }
+
+    // React to observable commitments. Story Arc is deliberately excluded: it is
+    // safer to keep the ground and punish its landing than to chase it upward.
+    if (grounded && ready && (
+      incoming ||
+      (opp.attack === 'throw' && distance < 42) ||
+      (opponentPhase.casting && CONTEXT_REACTIONS.has(opp.attack) && distance < 108) ||
+      (opp.y > 22 && distance < 52 && opponentPhase.active)
+    )) return special('context') ?? input;
+
+    if (
+      grounded && ready && this.config.contextClosingDistance > 0 &&
+      distance < this.config.contextClosingDistance && opponentClosing &&
+      opp.attack === 'none' && state.frame - this.lastContextFrame >= this.config.contextCooldown
+    ) return special('context') ?? input;
+
+    // Punish only when the chosen move can become active before recovery ends.
+    if (opponentPhase.recovering && ready) {
+      if (distance <= 29 && opp.y <= 3) {
+        input.throw = true;
+        this.lastActionFrame = state.frame;
+        record('throw');
+        return input;
+      }
+      if (distance <= 40 && opponentPhase.remaining >= ATTACKS.kick.startup) {
+        input.kick = true;
+        this.lastActionFrame = state.frame;
+        record('kick-punish');
+        return input;
+      }
+      if (
+        this.config.branchwalkMinRecovery > 0 &&
+        distance >= 42 && distance <= 72 &&
+        opponentPhase.remaining >= this.config.branchwalkMinRecovery
+      ) return special('branchwalk') ?? input;
+      if (distance < 72) {
+        input.moveX = toward;
+        return input;
+      }
+    }
+
+    // At point blank, throw is the shortest honest answer to passive guard. If the
+    // opponent attacks, the active-phase branch above changes this into defense.
+    if (distance <= 28 && opp.y <= 3 && ready) {
+      input.throw = true;
+      this.lastActionFrame = state.frame;
+      record('throw');
+      return input;
+    }
+
+    // A bounded poke prevents a losing policy from retreating forever, while a
+    // life lead keeps the controller from donating recovery frames.
+    if (
+      this.config.pokeWhenBehind && !ahead && !opponentClosing &&
+      distance >= 29 && distance <= 39 && state.frame - this.lastPokeFrame >= 24
+    ) {
+      input.kick = true;
+      this.lastPokeFrame = state.frame;
+      this.lastActionFrame = state.frame;
+      record('kick-poke');
+      return input;
+    }
+
+    const low = this.config.targetSpacing - 4;
+    const high = this.config.targetSpacing + 4;
+    if (distance < low || (ahead && distance < high + 12)) input.moveX = away;
+    else if (distance > high) input.moveX = toward;
+    return input;
+  }
+}

--- a/src/codex-live-logger-test.ts
+++ b/src/codex-live-logger-test.ts
@@ -1,0 +1,23 @@
+import { emptyInputs } from './game/types.js';
+import { inferDecisionReason, parseLoggerArgs, redactFingerprints } from './tools/codex-live-logger.js';
+import type { CombatObservation } from './bot/adaptive-codex-policy.js';
+
+let pass = true;
+const check = (name: string, ok: boolean) => { console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}`); if (!ok) pass = false; };
+
+const parsed = parseLoggerArgs(['--dry-run', '--identity', 'key', '--log', 'block.jsonl', '--expected-opponent', 'CODEX_MAC', '--expected-character', 'MNEME', '--source-commit', 'abc', '--matches', '5']);
+check('dry run remains disarmed and bounded', parsed.dryRun && !parsed.arm && parsed.matches === 5 && parsed.user === 'CODEX_AGENT');
+let rejected = false;
+try { parseLoggerArgs(['--arm', '--identity', 'key', '--log', 'x', '--expected-opponent', 'CODEX_MAC', '--expected-character', 'MNEME', '--source-commit', 'abc', '--user', 'SOMEONE']); } catch { rejected = true; }
+check('controller rejects identity-handle reassignment', rejected);
+
+const redacted = JSON.stringify(redactFingerprints({ fp: 'secret', match: { a_fp: 'a', b_fp: 'b', name: 'kept' }, rows: [{ fingerprint: 'x', hp: 4 }] }));
+check('fingerprints are recursively removed', !redacted.includes('secret') && !redacted.includes('a_fp') && !redacted.includes('fingerprint') && redacted.includes('kept'));
+
+const state = { frame: 9, phase: 'fight', you: { x: 10, y: 0, vx: 0, vy: 0, facing: 1, hp: 100, wins: 0, attack: 'none', attackFrame: 0, stun: 0, crouching: false }, opp: { x: 80, y: 0, vx: 0, vy: 0, facing: -1, hp: 100, wins: 0, attack: 'none', attackFrame: 0, stun: 0, crouching: false }, round: 1, roundTime: 99, projectiles: [] } as CombatObservation;
+const input = emptyInputs(); input.moveX = 1;
+check('movement reason is deterministic', inferDecisionReason(state, input, new Map(), new Map()) === 'spacing-toward');
+check('policy counters take precedence as reasons', inferDecisionReason(state, input, new Map(), new Map([['context', 1]])) === 'context');
+
+console.log(pass ? '\nCODEX LIVE LOGGER TEST: PASS' : '\nCODEX LIVE LOGGER TEST: FAIL');
+process.exit(pass ? 0 : 1);

--- a/src/tools/codex-live-logger.ts
+++ b/src/tools/codex-live-logger.ts
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+// Fixed CODEX controller with an append-only, total-order training log.
+// It cannot connect unless --arm is explicit, never logs key material, accepts
+// challenges only from the configured handle, and pauses for a HAM check after
+// every official match boundary.
+import { createHash } from 'node:crypto';
+import { spawn } from 'node:child_process';
+import { createReadStream, createWriteStream } from 'node:fs';
+import { access } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import readline from 'node:readline';
+import { fileURLToPath } from 'node:url';
+import { AdaptiveCodexPolicy, DEFAULT_ADAPTIVE_CONFIG, type CombatObservation } from '../bot/adaptive-codex-policy.js';
+import type { Inputs } from '../game/types.js';
+
+export const CONTROLLER_ID = 'adaptive-codex-fable-v2';
+export const CONTROLLER_CONFIG = DEFAULT_ADAPTIVE_CONFIG;
+
+export interface LoggerArgs {
+  arm: boolean; dryRun: boolean; user: 'CODEX_AGENT'; identity: string; host: string;
+  log: string; expectedOpponent: string; expectedCharacter: string; matches: number; sourceCommit: string;
+}
+
+const VALUE_OPTIONS = new Set(['identity', 'user', 'host', 'log', 'expected-opponent', 'expected-character', 'matches', 'source-commit']);
+export function parseLoggerArgs(argv: string[]): LoggerArgs {
+  const raw: Record<string, string | boolean> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i]!;
+    if (!token.startsWith('--')) throw new Error(`unexpected argument: ${token}`);
+    const name = token.slice(2);
+    if (!VALUE_OPTIONS.has(name) && name !== 'arm' && name !== 'dry-run') throw new Error(`unknown option: --${name}`);
+    if (VALUE_OPTIONS.has(name)) {
+      const next = argv[i + 1];
+      if (!next || next.startsWith('--')) throw new Error(`--${name} requires a value`);
+      raw[name] = next; i++;
+    } else raw[name] = true;
+  }
+  const required = (name: string): string => {
+    const value = raw[name]; if (typeof value !== 'string' || !value) throw new Error(`--${name} is required`); return value;
+  };
+  const user = (raw.user ?? 'CODEX_AGENT') as string;
+  if (user !== 'CODEX_AGENT') throw new Error('this frozen controller is restricted to --user CODEX_AGENT');
+  const matches = Number(raw.matches ?? '1');
+  if (!Number.isInteger(matches) || matches < 1 || matches > 5) throw new Error('--matches must be an integer from 1 to 5');
+  const arm = raw.arm === true, dryRun = raw['dry-run'] === true;
+  if (arm === dryRun) throw new Error('choose exactly one of --arm or --dry-run');
+  return {
+    arm, dryRun, user: 'CODEX_AGENT', identity: required('identity'), host: (raw.host as string | undefined) ?? 'sshfighter.com',
+    log: required('log'), expectedOpponent: required('expected-opponent'), expectedCharacter: required('expected-character').toUpperCase(),
+    matches, sourceCommit: required('source-commit'),
+  };
+}
+
+export function redactFingerprints(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(redactFingerprints);
+  if (!value || typeof value !== 'object') return value;
+  const result: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    if (key === 'fp' || key === 'a_fp' || key === 'b_fp' || key === 'fingerprint') continue;
+    result[key] = redactFingerprints(child);
+  }
+  return result;
+}
+
+export function inferDecisionReason(state: CombatObservation, input: Inputs, before: ReadonlyMap<string, number>, after: ReadonlyMap<string, number>): string {
+  for (const [name, count] of after) if (count > (before.get(name) ?? 0)) return name;
+  if (state.phase !== 'fight') return 'neutral-phase';
+  if (state.you.stun > 0 || state.you.attack !== 'none') return 'locked';
+  const toward = Math.sign(state.opp.x - state.you.x) || state.you.facing;
+  if (input.moveX === toward) return 'spacing-toward';
+  if (input.moveX === -toward) return 'spacing-away';
+  return 'neutral';
+}
+
+async function fileSha256(path: string): Promise<string> {
+  const hash = createHash('sha256');
+  for await (const chunk of createReadStream(path)) hash.update(chunk);
+  return hash.digest('hex');
+}
+
+interface OrderedLog {
+  record(kind: string, data: Record<string, unknown>): number;
+  close(): Promise<string>;
+}
+
+function orderedLog(path: string): OrderedLog {
+  const stream = createWriteStream(path, { flags: 'wx' });
+  let sequence = 0;
+  let closed = false;
+  const record = (kind: string, data: Record<string, unknown>): number => {
+    if (closed) throw new Error('attempted to write a closed log');
+    const current = sequence++;
+    const row = { sequence: current, wall_time: new Date().toISOString(), monotonic_ns: process.hrtime.bigint().toString(), kind, ...data };
+    if (!stream.write(`${JSON.stringify(row)}\n`)) stream.once('drain', () => {});
+    return current;
+  };
+  const close = async (): Promise<string> => {
+    if (!closed) { closed = true; await new Promise<void>((ok, fail) => stream.end(ok).once('error', fail)); }
+    return fileSha256(path);
+  };
+  return { record, close };
+}
+
+async function fetchOfficial(baseUrl: string, matchId: string): Promise<Record<string, unknown> | null> {
+  for (let attempt = 0; attempt < 10; attempt++) {
+    try {
+      const response = await fetch(`${baseUrl}/api/matches/${encodeURIComponent(matchId)}`, { headers: { accept: 'application/json' } });
+      if (response.ok) return redactFingerprints(await response.json()) as Record<string, unknown>;
+    } catch { /* bounded retry while the recorder commits */ }
+    await new Promise((ok) => setTimeout(ok, 250 * (attempt + 1)));
+  }
+  return null;
+}
+
+async function ensurePreflight(args: LoggerArgs): Promise<{ launcherSha: string; policySha: string }> {
+  await access(args.identity);
+  try { await access(args.log); throw new Error(`log already exists: ${args.log}`); } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+  const launcher = fileURLToPath(import.meta.url);
+  const policy = resolve(fileURLToPath(new URL('../bot/adaptive-codex-policy.ts', import.meta.url)));
+  return { launcherSha: await fileSha256(launcher), policySha: await fileSha256(policy) };
+}
+
+export async function runLoggedController(args: LoggerArgs): Promise<void> {
+  const hashes = await ensurePreflight(args);
+  const safeSummary = {
+    controller_id: CONTROLLER_ID, deterministic: true, local_seed: null, config: CONTROLLER_CONFIG,
+    source_commit: args.sourceCommit, launcher_sha256: hashes.launcherSha, policy_sha256: hashes.policySha,
+    user: args.user, fighter: 'CODEX', expected_opponent: args.expectedOpponent,
+    expected_character: args.expectedCharacter, matches: args.matches, log: args.log,
+  };
+  if (args.dryRun) { console.log(JSON.stringify({ ready: true, armed: false, ...safeSummary }, null, 2)); return; }
+
+  const log = orderedLog(args.log);
+  log.record('session', { ...safeSummary, armed: true, redactions: ['fingerprints', 'identity path', 'key material'] });
+  const ssh = spawn('ssh', ['-T', '-i', args.identity, '-o', 'IdentitiesOnly=yes', `${args.user}@${args.host}`, 'play'], { stdio: ['pipe', 'pipe', 'inherit'] });
+  const lines = readline.createInterface({ input: ssh.stdout });
+  const commands = readline.createInterface({ input: process.stdin, terminal: false });
+  const policy = new AdaptiveCodexPolicy();
+  let roster: string[] = [], matchId = '', opponent = '', completed = 0, pendingBoundary = false, fatal: Error | null = null;
+
+  const send = (message: Record<string, unknown>, causeSequence: number | null = null): void => {
+    log.record('emit', { cause_sequence: causeSequence, message });
+    if (!ssh.stdin.destroyed) ssh.stdin.write(`${JSON.stringify(message)}\n`);
+  };
+  const join = (): void => { pendingBoundary = false; send({ t: 'joinLounge', char: 'CODEX' }); };
+
+  commands.on('line', (line) => {
+    if (line.trim().toLowerCase() !== 'continue' || !pendingBoundary) return;
+    log.record('ham-boundary-ack', { completed });
+    join();
+  });
+
+  const finalizeMatch = async (message: Record<string, unknown>, inboundSequence: number): Promise<void> => {
+    const official = matchId ? await fetchOfficial(`https://${args.host}`, matchId) : null;
+    const match = official?.match as Record<string, unknown> | undefined;
+    const cleanKo = match?.end_reason === 'ko' && (match?.winner === 'a' || match?.winner === 'b');
+    completed++;
+    log.record('official-match', { cause_sequence: inboundSequence, match_id: matchId, clean_ko: cleanKo, payload: official });
+    log.record('ham-check-required', { completed, requested: args.matches, match_id: matchId });
+    console.log(`match boundary ${completed}/${args.matches}; clean_ko=${cleanKo}; check HAM before continuing`);
+    matchId = '';
+    if (completed >= args.matches) {
+      log.record('block-complete', { completed });
+      ssh.stdin.end();
+    } else {
+      pendingBoundary = true;
+      console.log('after HAM check, type: continue');
+    }
+  };
+
+  lines.on('line', (raw) => {
+    const line = raw.trim(); if (!line.startsWith('{')) return;
+    let message: Record<string, unknown>;
+    try { message = JSON.parse(line) as Record<string, unknown>; } catch { return; }
+    const safeMessage = redactFingerprints(message) as Record<string, unknown>;
+    const inboundSequence = log.record('inbound', { message: safeMessage });
+    if (message.t === 'welcome') {
+      roster = Array.isArray(message.roster) ? message.roster.map(String) : [];
+      join();
+    } else if (message.t === 'challengeState') {
+      const incoming = message.incoming as { name?: unknown } | null | undefined;
+      if (!incoming?.name) return;
+      if (String(incoming.name).toLowerCase() === args.expectedOpponent.toLowerCase()) send({ t: 'acceptChallenge' });
+      else send({ t: 'declineChallenge' });
+    } else if (message.t === 'matchStart') {
+      matchId = String(message.mid ?? ''); opponent = String(message.oppName ?? '');
+      const oppCharacter = roster[Number(message.oppCursor)] ?? 'UNKNOWN';
+      const ownershipOk = opponent.toLowerCase() === args.expectedOpponent.toLowerCase() && oppCharacter === args.expectedCharacter;
+      policy.reset();
+      log.record('match-provenance', { match_id: matchId, role: message.role, stage: message.stage, opponent, opponent_character: oppCharacter, ownership_ok: ownershipOk });
+      if (!ownershipOk) console.error('ownership mismatch: match will finish cleanly but must be excluded');
+    } else if (message.t === 'state') {
+      const state = message as unknown as CombatObservation;
+      if (!state.you || !state.opp || pendingBoundary) return;
+      const before = new Map(policy.actions);
+      const input = policy.decide(state);
+      const reason = inferDecisionReason(state, input, before, policy.actions);
+      log.record('decision', { match_id: matchId, state_frame: state.frame, state_ack: (message.ack as number | undefined) ?? null, reason, action: input });
+      send({ t: 'input', ...input }, inboundSequence);
+    } else if (message.t === 'matchEnd') {
+      void finalizeMatch(message, inboundSequence).catch((error) => { fatal = error as Error; ssh.stdin.end(); });
+    } else if (message.t === 'error') {
+      console.error(`server error: ${String(message.msg)}`);
+    }
+  });
+
+  await new Promise<void>((ok, fail) => {
+    ssh.once('error', fail);
+    ssh.once('exit', (code) => code === 0 || completed >= args.matches ? ok() : fail(new Error(`ssh exited ${code}`)));
+  });
+  lines.close(); commands.close();
+  if (fatal) throw fatal;
+  const digest = await log.close();
+  console.log(JSON.stringify({ complete: completed >= args.matches, matches: completed, log: args.log, sha256: digest }, null, 2));
+}
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+if (isMain) {
+  try { await runLoggedController(parseLoggerArgs(process.argv.slice(2))); }
+  catch (error) { console.error((error as Error).message); process.exitCode = 1; }
+}


### PR DESCRIPTION
## What changed

- Adds a fixed deterministic CODEX controller (`adaptive-codex-fable-v2`) with an append-only, total-order JSONL transport logger.
- Records inbound protocol state, policy decision/reason, emitted input, match provenance, and the sanitized official post-match record.
- Restricts the controller to `CODEX_AGENT`, validates the exact expected opponent handle and character, recursively removes fingerprints, and never logs identity/key paths.
- Refuses output overwrite and will not connect unless `--arm` is explicit; `--dry-run` performs provenance and filesystem preflight only.
- Pauses after every match with a `ham-check-required` record and requires an interactive `continue`, so a five-match block can check coordination state at every boundary.
- If ownership metadata is wrong after a match has started, it finishes cleanly and marks the record excluded rather than manufacturing a forfeit.

## Why

Aggregate action counters are not sufficient for temporal policy or latent-state training. This supplies the missing ordered state/decision/action stream while preserving direct-Lounge ownership and reproducibility boundaries.

## Impact

The new tool is disarmed by default and has no effect on ordinary SSH play, the bot API, game balance, or matchmaking. The policy is deterministic and records `local_seed=null` instead of inventing a seed.

## Validation

- `pnpm test`
- Focused argument, identity restriction, fingerprint-redaction, and decision-reason tests
- Dry-run against the reserved five-match artifact path; no connection, queue, Lounge entry, challenge, match, or output file was created
