### PR TITLE
add deterministic XENON policy search lab

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
     "test:bot": "tsx src/bot-server-test.ts",
     "test:newwave": "tsx src/newwave-test.ts",
     "test:gym": "tsx src/sparring-gym-test.ts",
+    "test:policy-lab": "tsx src/xenon-policy-lab-test.ts",
     "test:example-bot": "node examples/bot-test.mjs",
-    "test": "pnpm typecheck && pnpm test:engine && pnpm test:assets && pnpm test:db && pnpm test:input && pnpm test:render && pnpm test:hud && pnpm test:telemetry && pnpm test:recorder && pnpm test:coordinator && pnpm test:bot && pnpm test:newwave && pnpm test:gym && pnpm test:example-bot",
+    "test": "pnpm typecheck && pnpm test:engine && pnpm test:assets && pnpm test:db && pnpm test:input && pnpm test:render && pnpm test:hud && pnpm test:telemetry && pnpm test:recorder && pnpm test:coordinator && pnpm test:bot && pnpm test:newwave && pnpm test:gym && pnpm test:policy-lab && pnpm test:example-bot",
     "test:e2e": "tsx src/navigation-test.ts && tsx src/social-test.ts && tsx src/ssh-test.ts && tsx src/practice-test.ts",
     "gym": "tsx src/tools/omega-gym.ts",
+    "policy:xenon": "tsx src/tools/xenon-policy-lab.ts",
     "render-test": "tsx src/render-test.ts",
     "keygen": "mkdir -p keys && if [ ! -f keys/host.key ]; then ssh-keygen -t ed25519 -f keys/host.key -N \"\"; fi"
   },

--- a/src/tools/xenon-policy-lab.ts
+++ b/src/tools/xenon-policy-lab.ts
@@ -122,7 +122,8 @@ export interface MatchResult {
   winner: 'executor' | 'opponent';
   outcome: Outcome;
   terminal: 'ko' | 'time' | 'double-ko' | 'frame-cap';
-  cleanKo: boolean;
+  koTerminal: boolean;
+  cleanKoWin: boolean;
   roundTerminals: RoundTerminal[];
 }
 
@@ -130,9 +131,12 @@ export interface Aggregate {
   played: number;
   wins: number;
   losses: number;
-  cleanKos: number;
+  koTerminals: number;
+  cleanKoWins: number;
+  timeoutWins: number;
+  timeoutLosses: number;
   winRate: number;
-  cleanKoRate: number;
+  cleanKoWinRate: number;
   roundsWon: number;
   roundsLost: number;
 }
@@ -531,7 +535,7 @@ function playMatch(
     winner: executorWins ? 'executor' : 'opponent', outcome: executorWins ? 'win' : 'loss',
     // Only a KO earns the clean-KO metric. Time remains an authoritative result,
     // but is not promoted to equivalent combat evidence.
-    terminal, cleanKo: terminal === 'ko', roundTerminals,
+    terminal, koTerminal: terminal === 'ko', cleanKoWin: executorWins && terminal === 'ko', roundTerminals,
   };
 }
 
@@ -539,11 +543,15 @@ function aggregate(matches: MatchResult[]): Aggregate {
   const wins = matches.filter((m) => m.outcome === 'win').length;
   const roundsWon = matches.reduce((sum, m) => sum + m.rounds.executor, 0);
   const roundsLost = matches.reduce((sum, m) => sum + m.rounds.opponent, 0);
-  const cleanKos = matches.filter((m) => m.cleanKo).length;
+  const koTerminals = matches.filter((m) => m.koTerminal).length;
+  const cleanKoWins = matches.filter((m) => m.cleanKoWin).length;
+  const timeoutWins = matches.filter((m) => m.terminal === 'time' && m.outcome === 'win').length;
+  const timeoutLosses = matches.filter((m) => m.terminal === 'time' && m.outcome === 'loss').length;
   return {
-    played: matches.length, wins, losses: matches.length - wins, cleanKos,
+    played: matches.length, wins, losses: matches.length - wins,
+    koTerminals, cleanKoWins, timeoutWins, timeoutLosses,
     winRate: matches.length ? wins / matches.length : 0,
-    cleanKoRate: matches.length ? cleanKos / matches.length : 0,
+    cleanKoWinRate: matches.length ? cleanKoWins / matches.length : 0,
     roundsWon, roundsLost,
   };
 }
@@ -568,7 +576,7 @@ function scenarios(
 function score(summary: Aggregate): number {
   // Search only on train scenarios. A frame-cap/non-terminal match throws, while
   // timeout finals remain visible and are penalized rather than silently dropped.
-  return summary.wins * 1000 + (summary.roundsWon - summary.roundsLost) * 10 + summary.cleanKos;
+  return summary.wins * 1000 + (summary.roundsWon - summary.roundsLost) * 10 + summary.cleanKoWins;
 }
 
 function validateOptions(options: PolicyLabOptions): Required<PolicyLabOptions> {

--- a/src/tools/xenon-policy-lab.ts
+++ b/src/tools/xenon-policy-lab.ts
@@ -18,6 +18,9 @@ import { ENGINE_VERSION } from '../telemetry/recorder.js';
 
 export const ENGINE_COMMIT = '991acfe56ed096775dca728e2382fe56158d0a79';
 export const LAB_SCHEMA = 'xenon-policy-lab/v1';
+export const EXPECTED_MECHANICS_HASH = 'fdabc4c313f571c022c2d377dff123bb4ffa74ed334610faa6a6c70c74d5eea4';
+const EXPECTED_ENGINE_VERSION = 'sf-6';
+const MECHANICS_FILES = ['game/engine.ts', 'game/moves.ts', 'game/types.ts'] as const;
 const POLICY_SOURCE_VERSION = 'xenon-policy-lab-policies/v1';
 const DEFAULT_TRAIN_SEEDS = [101, 211, 307];
 const DEFAULT_HELD_OUT_SEEDS = [401, 503, 607];
@@ -100,6 +103,7 @@ export interface MatchResult {
   id: string;
   split: Split;
   scenarioSeed: number;
+  streamRootSeed: number;
   matchSeed: number;
   targetPolicySeed: number;
   opponentPolicySeed: number;
@@ -118,7 +122,7 @@ export interface MatchResult {
   winner: 'executor' | 'opponent';
   outcome: Outcome;
   terminal: 'ko' | 'time' | 'double-ko' | 'frame-cap';
-  cleanTerminal: boolean;
+  cleanKo: boolean;
   roundTerminals: RoundTerminal[];
 }
 
@@ -126,9 +130,9 @@ export interface Aggregate {
   played: number;
   wins: number;
   losses: number;
-  cleanTerminals: number;
+  cleanKos: number;
   winRate: number;
-  cleanRate: number;
+  cleanKoRate: number;
   roundsWon: number;
   roundsLost: number;
 }
@@ -164,9 +168,12 @@ export interface PolicyLabResult {
   schema: typeof LAB_SCHEMA;
   engine: {
     version: string;
-    commit: string;
-    engineSourceHash: string;
-    exactEngine: true;
+    expectedBaseCommit: string;
+    mechanicsHash: string;
+    expectedMechanicsHash: string;
+    mechanicsFiles: string[];
+    mechanicsValidated: true;
+    validationScope: string;
     networkAccess: false;
   };
   run: {
@@ -216,6 +223,24 @@ function hash(value: string | Uint8Array): string {
 
 function hashConfig(config: object): string {
   return hash(stable(config));
+}
+
+function computeMechanicsHash(): string {
+  const toolsDirectory = fileURLToPath(new URL('.', import.meta.url));
+  const digest = createHash('sha256');
+  for (const relative of MECHANICS_FILES) {
+    const sourcePath = resolve(toolsDirectory, '..', relative);
+    digest.update(`src/${relative}`).update('\0').update(readFileSync(sourcePath)).update('\0');
+  }
+  return digest.digest('hex');
+}
+
+/** Fail closed if the mechanics snapshot is not the reviewed sf-6 base. */
+export function validateMechanicsSnapshot(actualHash: string, engineVersion = ENGINE_VERSION): void {
+  if (engineVersion !== EXPECTED_ENGINE_VERSION)
+    throw new Error(`engine version mismatch: expected ${EXPECTED_ENGINE_VERSION}, got ${engineVersion}`);
+  if (actualHash !== EXPECTED_MECHANICS_HASH)
+    throw new Error(`mechanics snapshot mismatch: expected ${EXPECTED_MECHANICS_HASH}, got ${actualHash}`);
 }
 
 function mulberry32(seed: number): () => number {
@@ -444,9 +469,14 @@ function playMatch(
   seed: number,
   inputDelay: number,
 ): MatchResult {
-  const matchSeed = deriveSeed(runSeed, seed, split, executorSide, opponent.id, target.configHash);
-  const targetPolicySeed = deriveSeed(matchSeed, 'target');
-  const opponentPolicySeed = deriveSeed(matchSeed, 'opponent');
+  // Common-random-number design: every candidate and both seat assignments see
+  // the same stochastic streams for a given split/opponent/scenario. Candidate
+  // config and executor side affect result identity only, never RNG. Explicit
+  // role labels keep engine, target, and opponent streams disjoint.
+  const streamRootSeed = deriveSeed(runSeed, split, opponent.id, seed, 'common-random-numbers-v1');
+  const matchSeed = deriveSeed(streamRootSeed, 'engine-stream');
+  const targetPolicySeed = deriveSeed(streamRootSeed, 'target-policy-stream');
+  const opponentPolicySeed = deriveSeed(streamRootSeed, 'opponent-policy-stream');
   const targetInstance = target.create(targetPolicySeed);
   const opponentInstance = opponent.create(opponentPolicySeed);
   const aCharacter = executorSide === 'a' ? 'XENON' : opponent.character;
@@ -491,17 +521,17 @@ function playMatch(
   const last = roundTerminals.at(-1);
   const terminal = last?.reason ?? 'frame-cap';
   return {
-    id: hash(`${matchSeed}|${target.id}|${opponent.id}`).slice(0, 16), split,
-    scenarioSeed: seed, matchSeed, targetPolicySeed, opponentPolicySeed,
+    id: hash(`${matchSeed}|${target.id}|${target.configHash}|${opponent.id}|${executorSide}|${inputDelay}`).slice(0, 16), split,
+    scenarioSeed: seed, streamRootSeed, matchSeed, targetPolicySeed, opponentPolicySeed,
     executorSide, executor: 'XENON', opponent: opponent.character as OpponentName,
     opponentPolicy: opponent.id, opponentFamily: opponent.family, opponentConfigHash: opponent.configHash,
     targetPolicy: target.id, targetConfigHash: target.configHash, inputDelay, stage: match.stage,
     frames: match.frame,
     rounds: { executor: executorSide === 'a' ? match.a.wins : match.b.wins, opponent: executorSide === 'a' ? match.b.wins : match.a.wins },
     winner: executorWins ? 'executor' : 'opponent', outcome: executorWins ? 'win' : 'loss',
-    // KO and time are authoritative engine endings. There is no disconnect,
-    // forfeit, queue race, or inferred result in this offline harness.
-    terminal, cleanTerminal: terminal === 'ko' || terminal === 'time', roundTerminals,
+    // Only a KO earns the clean-KO metric. Time remains an authoritative result,
+    // but is not promoted to equivalent combat evidence.
+    terminal, cleanKo: terminal === 'ko', roundTerminals,
   };
 }
 
@@ -509,11 +539,11 @@ function aggregate(matches: MatchResult[]): Aggregate {
   const wins = matches.filter((m) => m.outcome === 'win').length;
   const roundsWon = matches.reduce((sum, m) => sum + m.rounds.executor, 0);
   const roundsLost = matches.reduce((sum, m) => sum + m.rounds.opponent, 0);
-  const cleanTerminals = matches.filter((m) => m.cleanTerminal).length;
+  const cleanKos = matches.filter((m) => m.cleanKo).length;
   return {
-    played: matches.length, wins, losses: matches.length - wins, cleanTerminals,
+    played: matches.length, wins, losses: matches.length - wins, cleanKos,
     winRate: matches.length ? wins / matches.length : 0,
-    cleanRate: matches.length ? cleanTerminals / matches.length : 0,
+    cleanKoRate: matches.length ? cleanKos / matches.length : 0,
     roundsWon, roundsLost,
   };
 }
@@ -538,7 +568,7 @@ function scenarios(
 function score(summary: Aggregate): number {
   // Search only on train scenarios. A frame-cap/non-terminal match throws, while
   // timeout finals remain visible and are penalized rather than silently dropped.
-  return summary.wins * 1000 + (summary.roundsWon - summary.roundsLost) * 10 + summary.cleanTerminals;
+  return summary.wins * 1000 + (summary.roundsWon - summary.roundsLost) * 10 + summary.cleanKos;
 }
 
 function validateOptions(options: PolicyLabOptions): Required<PolicyLabOptions> {
@@ -558,6 +588,8 @@ function validateOptions(options: PolicyLabOptions): Required<PolicyLabOptions> 
 
 export async function runPolicyLab(options: PolicyLabOptions = {}): Promise<PolicyLabResult> {
   const checked = validateOptions(options);
+  const mechanicsHash = computeMechanicsHash();
+  validateMechanicsSnapshot(mechanicsHash);
   const ensemble = new Map<string, PolicyDefinition>();
   for (const split of ['train', 'held-out'] as const) for (const character of DEFAULT_OPPONENTS)
     ensemble.set(`${split}:${character}`, opponentPolicy(character, split));
@@ -590,7 +622,6 @@ export async function runPolicyLab(options: PolicyLabOptions = {}): Promise<Poli
   };
 
   const thisFile = fileURLToPath(import.meta.url);
-  const engineFile = resolve(fileURLToPath(new URL('.', import.meta.url)), '../game/engine.ts');
   const opponentEnsemble = [...ensemble.entries()].map(([key, policy]) => ({
     split: key.startsWith('train:') ? 'train' as const : 'held-out' as const,
     character: policy.character as OpponentName, policyId: policy.id, family: policy.family,
@@ -600,9 +631,11 @@ export async function runPolicyLab(options: PolicyLabOptions = {}): Promise<Poli
   return {
     schema: LAB_SCHEMA,
     engine: {
-      version: ENGINE_VERSION, commit: ENGINE_COMMIT,
-      engineSourceHash: hash(readFileSync(engineFile, 'utf8')),
-      exactEngine: true, networkAccess: false,
+      version: ENGINE_VERSION, expectedBaseCommit: ENGINE_COMMIT,
+      mechanicsHash, expectedMechanicsHash: EXPECTED_MECHANICS_HASH,
+      mechanicsFiles: MECHANICS_FILES.map((file) => `src/${file}`), mechanicsValidated: true,
+      validationScope: 'Exact mechanics snapshot only; stage art/selection and sprites are excluded because the lab pins the cosmetic stage and does not render.',
+      networkAccess: false,
     },
     run: {
       seed: checked.seed, trainSeeds: [...checked.trainSeeds], heldOutSeeds: [...checked.heldOutSeeds],

--- a/src/tools/xenon-policy-lab.ts
+++ b/src/tools/xenon-policy-lab.ts
@@ -1,0 +1,666 @@
+// Offline-only policy search/evaluation for XENON. This drives the exact game
+// engine directly: it never imports networking, matchmaking, database, or live
+// bot-server code.
+//
+// The lab deliberately observes raw `attack` + `attackFrame`. Convenience
+// `special`/`active`/`casting` flags have drifted from the canonical move table
+// before and are not part of this experiment's evidence.
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { resolve } from 'node:path';
+import { makeFighter, makeMatch, stepMatch, TICK_HZ } from '../game/engine.js';
+import { emptyInputs } from '../game/types.js';
+import type { AttackKind, Fighter, Inputs, Match, MatchPhase, Projectile } from '../game/types.js';
+import { specialMoveForAttack, specialMoveMotionCode } from '../game/moves.js';
+import type { SpecialAttack } from '../game/moves.js';
+import { ENGINE_VERSION } from '../telemetry/recorder.js';
+
+export const ENGINE_COMMIT = '991acfe56ed096775dca728e2382fe56158d0a79';
+export const LAB_SCHEMA = 'xenon-policy-lab/v1';
+const POLICY_SOURCE_VERSION = 'xenon-policy-lab-policies/v1';
+const DEFAULT_TRAIN_SEEDS = [101, 211, 307];
+const DEFAULT_HELD_OUT_SEEDS = [401, 503, 607];
+const DEFAULT_OPPONENTS = ['OMEGA', 'MNEME', 'AJAX', 'FABLE'] as const;
+// Three full 60-second rounds plus countdown/inter-round ceremony fit below this
+// cap. Reaching it is an error, never a draw silently folded into evaluation.
+const MAX_MATCH_FRAMES = TICK_HZ * 210;
+
+type Side = 'a' | 'b';
+type Split = 'train' | 'held-out';
+type Outcome = 'win' | 'loss';
+type OpponentName = typeof DEFAULT_OPPONENTS[number];
+
+export interface RawFighterObservation {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  facing: 1 | -1;
+  hp: number;
+  wins: number;
+  attack: AttackKind;
+  attackFrame: number;
+  stun: number;
+  blocking: boolean;
+  crouching: boolean;
+  phaseT: number;
+  armorT: number;
+}
+
+export interface ProjectileObservation {
+  owner: 'self' | 'opponent';
+  x: number;
+  y: number;
+  vx: number;
+  style: Projectile['style'];
+  frame: number;
+  returning: boolean;
+}
+
+interface PolicyContext {
+  self: RawFighterObservation;
+  opponent: RawFighterObservation;
+  projectiles: ProjectileObservation[];
+  phase: MatchPhase;
+  frame: number;
+  side: Side;
+}
+
+interface PolicyInstance {
+  decide(context: PolicyContext): Inputs;
+}
+
+interface PolicyDefinition {
+  id: string;
+  character: string;
+  family: string;
+  config: object;
+  sourceHash: string;
+  configHash: string;
+  create(seed: number): PolicyInstance;
+}
+
+export interface XenonConfig {
+  projectileReflectDistance: number;
+  phaseThreatDistance: number;
+  phaseNeutralDistance: number;
+  blinkDistance: number;
+  closeThrowChance: number;
+  jumpKickChance: number;
+}
+
+export interface RoundTerminal {
+  round: number;
+  reason: 'ko' | 'time' | 'double-ko';
+  winner: Side | 'draw';
+}
+
+export interface MatchResult {
+  id: string;
+  split: Split;
+  scenarioSeed: number;
+  matchSeed: number;
+  targetPolicySeed: number;
+  opponentPolicySeed: number;
+  executorSide: Side;
+  executor: 'XENON';
+  opponent: OpponentName;
+  opponentPolicy: string;
+  opponentFamily: string;
+  opponentConfigHash: string;
+  targetPolicy: string;
+  targetConfigHash: string;
+  inputDelay: number;
+  stage: string;
+  frames: number;
+  rounds: { executor: number; opponent: number };
+  winner: 'executor' | 'opponent';
+  outcome: Outcome;
+  terminal: 'ko' | 'time' | 'double-ko' | 'frame-cap';
+  cleanTerminal: boolean;
+  roundTerminals: RoundTerminal[];
+}
+
+export interface Aggregate {
+  played: number;
+  wins: number;
+  losses: number;
+  cleanTerminals: number;
+  winRate: number;
+  cleanRate: number;
+  roundsWon: number;
+  roundsLost: number;
+}
+
+export interface CandidateSummary extends Aggregate {
+  rank?: number;
+  score: number;
+  policyId: string;
+  config: XenonConfig;
+  configHash: string;
+}
+
+export interface EvaluationBlock {
+  policyId: string;
+  policySourceHash: string;
+  config: object;
+  configHash: string;
+  train: Aggregate;
+  heldOut: Aggregate;
+  matches: MatchResult[];
+}
+
+export interface PolicyLabOptions {
+  seed?: number;
+  trainSeeds?: number[];
+  heldOutSeeds?: number[];
+  inputDelay?: number;
+  candidateLimit?: number;
+  includeSearchMatches?: boolean;
+}
+
+export interface PolicyLabResult {
+  schema: typeof LAB_SCHEMA;
+  engine: {
+    version: string;
+    commit: string;
+    engineSourceHash: string;
+    exactEngine: true;
+    networkAccess: false;
+  };
+  run: {
+    seed: number;
+    trainSeeds: number[];
+    heldOutSeeds: number[];
+    inputDelay: number;
+    opponents: OpponentName[];
+    sideAssignments: Side[];
+    candidateCount: number;
+  };
+  opponentEnsemble: Array<{
+    split: Split;
+    character: OpponentName;
+    policyId: string;
+    family: string;
+    sourceHash: string;
+    config: object;
+    configHash: string;
+  }>;
+  search: {
+    selectedPolicyId: string;
+    selectedConfig: XenonConfig;
+    selectedConfigHash: string;
+    candidates: CandidateSummary[];
+    matches?: MatchResult[];
+  };
+  evaluation: {
+    searched: EvaluationBlock;
+    frozenBaselines: EvaluationBlock[];
+  };
+  limitations: string[];
+}
+
+function stable(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stable).join(',')}]`;
+  if (value && typeof value === 'object') {
+    const object = value as Record<string, unknown>;
+    return `{${Object.keys(object).sort().map((key) => `${JSON.stringify(key)}:${stable(object[key])}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function hash(value: string | Uint8Array): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function hashConfig(config: object): string {
+  return hash(stable(config));
+}
+
+function mulberry32(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6D2B79F5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function deriveSeed(...parts: Array<number | string>): number {
+  const digest = createHash('sha256').update(parts.join('|')).digest();
+  return digest.readUInt32LE(0);
+}
+
+function raw(fighter: Fighter): RawFighterObservation {
+  return {
+    x: fighter.x, y: fighter.y, vx: fighter.vx, vy: fighter.vy,
+    facing: fighter.facing, hp: fighter.hp, wins: fighter.wins,
+    attack: fighter.attack, attackFrame: fighter.attackFrame, stun: fighter.stun,
+    blocking: fighter.blocking, crouching: fighter.crouching,
+    phaseT: fighter.phaseT, armorT: fighter.armorT,
+  };
+}
+
+function projectileView(projectiles: Projectile[], side: Side): ProjectileObservation[] {
+  return projectiles.filter((p) => p.active).map((p) => ({
+    owner: p.owner === side ? 'self' : 'opponent',
+    x: p.x, y: p.y, vx: p.vx, style: p.style, frame: p.frame,
+    returning: !!p.returning,
+  }));
+}
+
+function neutral(): Inputs {
+  return emptyInputs();
+}
+
+function move(moveX = 0, extras: Partial<Inputs> = {}): Inputs {
+  return { ...emptyInputs(), moveX, ...extras };
+}
+
+function special(character: string, attack: SpecialAttack, facing: 1 | -1): Inputs {
+  const definition = specialMoveForAttack(character, attack);
+  if (!definition) throw new Error(`${character} has no canonical ${attack} move`);
+  return {
+    ...emptyInputs(),
+    motion: specialMoveMotionCode(definition, facing),
+    punch: definition.button === 'punch',
+    kick: definition.button === 'kick',
+  };
+}
+
+function distance(context: PolicyContext): number {
+  return Math.abs(context.opponent.x - context.self.x);
+}
+
+function toward(context: PolicyContext): 1 | -1 {
+  return (context.opponent.x >= context.self.x ? 1 : -1);
+}
+
+function incomingProjectile(context: PolicyContext, maximumDistance: number): boolean {
+  return context.projectiles.some((p) => {
+    if (p.owner !== 'opponent' || p.style === 'construct' || p.style === 'rope') return false;
+    const delta = context.self.x - p.x;
+    return Math.abs(delta) <= maximumDistance && Math.sign(delta) === Math.sign(p.vx);
+  });
+}
+
+function canAct(context: PolicyContext): boolean {
+  return context.phase === 'fight' && context.self.stun <= 0 && context.self.attack === 'none';
+}
+
+function makeDefinition(
+  id: string,
+  character: string,
+  family: string,
+  config: object,
+  factory: (random: () => number) => PolicyInstance,
+): PolicyDefinition {
+  const sourceHash = hash(`${POLICY_SOURCE_VERSION}|${id}|${factory.toString()}`);
+  return {
+    id, character, family, config, sourceHash, configHash: hashConfig(config),
+    create(seed: number) { return factory(mulberry32(seed)); },
+  };
+}
+
+function opponentPolicy(character: OpponentName, split: Split): PolicyDefinition {
+  const heldOut = split === 'held-out';
+  const family = heldOut ? 'pressure-counter-v1' : 'canonical-specialist-v1';
+  const config = heldOut
+    ? { pressureDistance: 46, projectileReaction: 82, jumpChance: 0.18, specialCadence: 0.62 }
+    : { pressureDistance: 38, projectileReaction: 64, jumpChance: 0.08, specialCadence: 0.78 };
+
+  return makeDefinition(`${character.toLowerCase()}-${family}`, character, family, config, (random) => ({
+    decide(context) {
+      if (!canAct(context)) return neutral();
+      const dist = distance(context);
+      const dir = toward(context);
+      const away = -dir;
+      const threatened = context.opponent.attack !== 'none'
+        && context.opponent.attackFrame <= (heldOut ? 8 : 6)
+        && dist <= (heldOut ? 58 : 48);
+      const projectile = incomingProjectile(context, config.projectileReaction);
+
+      if (character === 'OMEGA') {
+        if (projectile || (threatened && dist < 52)) return special('OMEGA', 'nullstep', context.self.facing);
+        if (dist > (heldOut ? 104 : 84)) return special('OMEGA', 'testimony', context.self.facing);
+        if (dist > 42) return special('OMEGA', 'entropy', context.self.facing);
+      } else if (character === 'MNEME') {
+        const constructs = context.projectiles.filter((p) => p.owner === 'self' && p.style === 'construct').length;
+        if (projectile || threatened) return special('MNEME', 'nova', context.self.facing);
+        if (constructs < (heldOut ? 1 : 2) && dist > (heldOut ? 44 : 58)) return special('MNEME', 'construct', context.self.facing);
+        if (dist > 50) return special('MNEME', 'volley', context.self.facing);
+      } else if (character === 'AJAX') {
+        if (projectile || threatened) return special('AJAX', 'armor', context.self.facing);
+        if (dist > (heldOut ? 76 : 92)) return special('AJAX', 'boomerang', context.self.facing);
+        if (dist > 42) return special('AJAX', 'lasso', context.self.facing);
+      } else {
+        if (projectile || (context.opponent.y > 5 && dist < 64)) return special('FABLE', 'storyarc', context.self.facing);
+        if (threatened) return special('FABLE', 'plottwist', context.self.facing);
+        if (dist < 38) return special('FABLE', 'inktempest', context.self.facing);
+        if (heldOut && dist > 74) return special('FABLE', 'storyarc', context.self.facing);
+      }
+
+      // Family separation is behavioral, not merely a label/config change.
+      if (heldOut) {
+        if (context.self.y > 3 && dist < 48) return move(dir, { kick: true });
+        if (dist <= 28) return random() < 0.48 ? move(0, { throw: true }) : move(0, { kick: true });
+        if (threatened) return move(away, { down: true });
+        if (dist > 58 && random() < config.jumpChance) return move(dir, { jump: true });
+        return move(dist > config.pressureDistance ? dir : away, dist <= 44 ? { kick: true } : {});
+      }
+      if (dist <= 28) return random() < 0.34 ? move(0, { throw: true }) : move(0, { kick: true });
+      if (threatened) return move(away, { down: true });
+      return move(dist > config.pressureDistance ? dir : away, dist <= 42 ? { kick: true } : {});
+    },
+  }));
+}
+
+function xenonPolicy(id: string, family: string, config: XenonConfig): PolicyDefinition {
+  return makeDefinition(id, 'XENON', family, config, (random) => ({
+    decide(context) {
+      if (!canAct(context)) return neutral();
+      const dist = distance(context);
+      const dir = toward(context);
+      const away = -dir;
+      const opponentCommitted = context.opponent.attack !== 'none';
+
+      if (incomingProjectile(context, config.projectileReflectDistance))
+        return special('XENON', 'reflect', context.self.facing);
+      if (opponentCommitted && context.opponent.attackFrame <= 8 && dist <= config.phaseThreatDistance)
+        return special('XENON', 'phase', context.self.facing);
+      if (context.self.y > 3) return dist <= 48 ? move(dir, { kick: true }) : move(dir);
+      if (dist >= config.blinkDistance) return special('XENON', 'blink', context.self.facing);
+      if (dist >= config.phaseNeutralDistance) return special('XENON', 'phase', context.self.facing);
+      if (dist <= 27) return random() < config.closeThrowChance ? move(0, { throw: true }) : move(0, { kick: true });
+      if (dist <= 44) return move(0, { kick: true });
+      if (random() < config.jumpKickChance) return move(dir, { jump: true });
+      if (opponentCommitted && dist < 56) return move(away, { down: true });
+      return move(dir);
+    },
+  }));
+}
+
+function normalsBaseline(): PolicyDefinition {
+  const config = { spacing: 42, throwChance: 0.35, jumpChance: 0.08, specials: false };
+  return makeDefinition('xenon-frozen-normals-v1', 'XENON', 'frozen-baseline', config, (random) => ({
+    decide(context) {
+      if (!canAct(context)) return neutral();
+      const dist = distance(context), dir = toward(context), away = -dir;
+      if (context.self.y > 3) return dist < 46 ? move(dir, { kick: true }) : move(dir);
+      if (context.opponent.attack !== 'none' && dist < 48) return move(away, { down: true });
+      if (dist <= 28) return random() < config.throwChance ? move(0, { throw: true }) : move(0, { kick: true });
+      if (dist <= config.spacing) return move(0, { kick: true });
+      return random() < config.jumpChance ? move(dir, { jump: true }) : move(dir);
+    },
+  }));
+}
+
+function frozenXenonBaseline(): PolicyDefinition {
+  return xenonPolicy('xenon-frozen-hand-v1', 'frozen-baseline', {
+    projectileReflectDistance: 58,
+    phaseThreatDistance: 48,
+    phaseNeutralDistance: 82,
+    blinkDistance: 126,
+    closeThrowChance: 0.32,
+    jumpKickChance: 0.06,
+  });
+}
+
+function candidateConfigs(limit: number): XenonConfig[] {
+  const configs: XenonConfig[] = [];
+  for (const projectileReflectDistance of [44, 68, 92])
+    for (const phaseThreatDistance of [42, 54, 68])
+      for (const phaseNeutralDistance of [54, 76, 98])
+        for (const blinkDistance of [72, 108, 144])
+          for (const closeThrowChance of [0.2, 0.5])
+            for (const jumpKickChance of [0.03, 0.12])
+              configs.push({ projectileReflectDistance, phaseThreatDistance, phaseNeutralDistance, blinkDistance, closeThrowChance, jumpKickChance });
+  // Evenly span the deterministic grid when bounded, rather than selecting only
+  // the lexicographically earliest corner.
+  if (limit >= configs.length) return configs;
+  const selected: XenonConfig[] = [];
+  for (let i = 0; i < limit; i++) selected.push(configs[Math.floor(i * configs.length / limit)]!);
+  return selected;
+}
+
+class InputDelay {
+  private readonly queue: Inputs[] = [];
+  constructor(private readonly frames: number) {}
+  push(input: Inputs): Inputs {
+    this.queue.push({ ...input });
+    return this.queue.length > this.frames ? this.queue.shift()! : neutral();
+  }
+}
+
+function playMatch(
+  target: PolicyDefinition,
+  opponent: PolicyDefinition,
+  split: Split,
+  executorSide: Side,
+  runSeed: number,
+  seed: number,
+  inputDelay: number,
+): MatchResult {
+  const matchSeed = deriveSeed(runSeed, seed, split, executorSide, opponent.id, target.configHash);
+  const targetPolicySeed = deriveSeed(matchSeed, 'target');
+  const opponentPolicySeed = deriveSeed(matchSeed, 'opponent');
+  const targetInstance = target.create(targetPolicySeed);
+  const opponentInstance = opponent.create(opponentPolicySeed);
+  const aCharacter = executorSide === 'a' ? 'XENON' : opponent.character;
+  const bCharacter = executorSide === 'b' ? 'XENON' : opponent.character;
+  const match = makeMatch(makeFighter('a', aCharacter, 'a'), makeFighter('b', bCharacter, 'b'));
+  match.stage = 'dojo'; // stages are cosmetic; pin one to eliminate OS-CSPRNG provenance noise.
+  const delayA = new InputDelay(inputDelay);
+  const delayB = new InputDelay(inputDelay);
+  const roundTerminals: RoundTerminal[] = [];
+  let previousPhase: MatchPhase = match.phase;
+
+  for (let frame = 0; frame < MAX_MATCH_FRAMES && match.phase !== 'match-over'; frame++) {
+    const contextA: PolicyContext = {
+      self: raw(match.a), opponent: raw(match.b), projectiles: projectileView(match.projectiles, 'a'),
+      phase: match.phase, frame: match.frame, side: 'a',
+    };
+    const contextB: PolicyContext = {
+      self: raw(match.b), opponent: raw(match.a), projectiles: projectileView(match.projectiles, 'b'),
+      phase: match.phase, frame: match.frame, side: 'b',
+    };
+    const intendedA = executorSide === 'a' ? targetInstance.decide(contextA) : opponentInstance.decide(contextA);
+    const intendedB = executorSide === 'b' ? targetInstance.decide(contextB) : opponentInstance.decide(contextB);
+    stepMatch(match, delayA.push(intendedA), delayB.push(intendedB));
+
+    const currentPhase = match.phase as MatchPhase; // stepMatch mutates through the shared Match object.
+    if (previousPhase === 'fight' && (currentPhase === 'round-over' || currentPhase === 'match-over')) {
+      const aDead = match.a.hp <= 0, bDead = match.b.hp <= 0;
+      const reason = aDead && bDead ? 'double-ko' : (aDead || bDead ? 'ko' : 'time');
+      const winner: Side | 'draw' = match.a.wins > (roundTerminals.filter((r) => r.winner === 'a').length)
+        ? 'a'
+        : match.b.wins > (roundTerminals.filter((r) => r.winner === 'b').length) ? 'b' : 'draw';
+      roundTerminals.push({ round: match.round, reason, winner });
+    }
+    previousPhase = currentPhase;
+  }
+
+  if (match.phase !== 'match-over' || match.a.wins === match.b.wins)
+    throw new Error(`non-terminal offline match ${opponent.id}/${executorSide}/${seed}: phase=${match.phase} ${match.a.wins}-${match.b.wins}`);
+
+  const winnerSide: Side = match.a.wins > match.b.wins ? 'a' : 'b';
+  const executorWins = executorSide === winnerSide;
+  const last = roundTerminals.at(-1);
+  const terminal = last?.reason ?? 'frame-cap';
+  return {
+    id: hash(`${matchSeed}|${target.id}|${opponent.id}`).slice(0, 16), split,
+    scenarioSeed: seed, matchSeed, targetPolicySeed, opponentPolicySeed,
+    executorSide, executor: 'XENON', opponent: opponent.character as OpponentName,
+    opponentPolicy: opponent.id, opponentFamily: opponent.family, opponentConfigHash: opponent.configHash,
+    targetPolicy: target.id, targetConfigHash: target.configHash, inputDelay, stage: match.stage,
+    frames: match.frame,
+    rounds: { executor: executorSide === 'a' ? match.a.wins : match.b.wins, opponent: executorSide === 'a' ? match.b.wins : match.a.wins },
+    winner: executorWins ? 'executor' : 'opponent', outcome: executorWins ? 'win' : 'loss',
+    // KO and time are authoritative engine endings. There is no disconnect,
+    // forfeit, queue race, or inferred result in this offline harness.
+    terminal, cleanTerminal: terminal === 'ko' || terminal === 'time', roundTerminals,
+  };
+}
+
+function aggregate(matches: MatchResult[]): Aggregate {
+  const wins = matches.filter((m) => m.outcome === 'win').length;
+  const roundsWon = matches.reduce((sum, m) => sum + m.rounds.executor, 0);
+  const roundsLost = matches.reduce((sum, m) => sum + m.rounds.opponent, 0);
+  const cleanTerminals = matches.filter((m) => m.cleanTerminal).length;
+  return {
+    played: matches.length, wins, losses: matches.length - wins, cleanTerminals,
+    winRate: matches.length ? wins / matches.length : 0,
+    cleanRate: matches.length ? cleanTerminals / matches.length : 0,
+    roundsWon, roundsLost,
+  };
+}
+
+function scenarios(
+  target: PolicyDefinition,
+  split: Split,
+  seeds: number[],
+  runSeed: number,
+  inputDelay: number,
+  ensemble: Map<string, PolicyDefinition>,
+): MatchResult[] {
+  const results: MatchResult[] = [];
+  for (const opponentName of DEFAULT_OPPONENTS) {
+    const opponent = ensemble.get(`${split}:${opponentName}`)!;
+    for (const seed of seeds) for (const side of ['a', 'b'] as const)
+      results.push(playMatch(target, opponent, split, side, runSeed, seed, inputDelay));
+  }
+  return results;
+}
+
+function score(summary: Aggregate): number {
+  // Search only on train scenarios. A frame-cap/non-terminal match throws, while
+  // timeout finals remain visible and are penalized rather than silently dropped.
+  return summary.wins * 1000 + (summary.roundsWon - summary.roundsLost) * 10 + summary.cleanTerminals;
+}
+
+function validateOptions(options: PolicyLabOptions): Required<PolicyLabOptions> {
+  const seed = options.seed ?? 1;
+  const trainSeeds = options.trainSeeds ?? DEFAULT_TRAIN_SEEDS;
+  const heldOutSeeds = options.heldOutSeeds ?? DEFAULT_HELD_OUT_SEEDS;
+  const inputDelay = options.inputDelay ?? 0;
+  const candidateLimit = options.candidateLimit ?? 48;
+  if (!Number.isInteger(seed)) throw new Error('seed must be an integer');
+  if (!trainSeeds.length || !heldOutSeeds.length || [...trainSeeds, ...heldOutSeeds].some((s) => !Number.isInteger(s)))
+    throw new Error('train and held-out seeds must be non-empty integer lists');
+  if (trainSeeds.some((s) => heldOutSeeds.includes(s))) throw new Error('train and held-out seeds must be disjoint');
+  if (!Number.isInteger(inputDelay) || inputDelay < 0 || inputDelay > 30) throw new Error('inputDelay must be an integer from 0 to 30');
+  if (!Number.isInteger(candidateLimit) || candidateLimit < 1 || candidateLimit > 324) throw new Error('candidateLimit must be an integer from 1 to 324');
+  return { seed, trainSeeds, heldOutSeeds, inputDelay, candidateLimit, includeSearchMatches: options.includeSearchMatches ?? false };
+}
+
+export async function runPolicyLab(options: PolicyLabOptions = {}): Promise<PolicyLabResult> {
+  const checked = validateOptions(options);
+  const ensemble = new Map<string, PolicyDefinition>();
+  for (const split of ['train', 'held-out'] as const) for (const character of DEFAULT_OPPONENTS)
+    ensemble.set(`${split}:${character}`, opponentPolicy(character, split));
+
+  const candidateRows: CandidateSummary[] = [];
+  const searchMatches: MatchResult[] = [];
+  for (const [index, config] of candidateConfigs(checked.candidateLimit).entries()) {
+    const target = xenonPolicy(`xenon-search-${index.toString().padStart(3, '0')}`, 'searched-grid-v1', config);
+    const matches = scenarios(target, 'train', checked.trainSeeds, checked.seed, checked.inputDelay, ensemble);
+    const totals = aggregate(matches);
+    candidateRows.push({ ...totals, score: score(totals), policyId: target.id, config, configHash: target.configHash });
+    if (checked.includeSearchMatches) searchMatches.push(...matches);
+  }
+  candidateRows.sort((a, b) => b.score - a.score || a.configHash.localeCompare(b.configHash));
+  candidateRows.forEach((row, index) => { row.rank = index + 1; });
+  const selected = candidateRows[0]!;
+  const selectedPolicy = xenonPolicy(selected.policyId, 'searched-grid-v1', selected.config);
+
+  const evaluate = (policy: PolicyDefinition): EvaluationBlock => {
+    const matches = [
+      ...scenarios(policy, 'train', checked.trainSeeds, checked.seed, checked.inputDelay, ensemble),
+      ...scenarios(policy, 'held-out', checked.heldOutSeeds, checked.seed, checked.inputDelay, ensemble),
+    ];
+    return {
+      policyId: policy.id, policySourceHash: policy.sourceHash, config: policy.config, configHash: policy.configHash,
+      train: aggregate(matches.filter((m) => m.split === 'train')),
+      heldOut: aggregate(matches.filter((m) => m.split === 'held-out')),
+      matches,
+    };
+  };
+
+  const thisFile = fileURLToPath(import.meta.url);
+  const engineFile = resolve(fileURLToPath(new URL('.', import.meta.url)), '../game/engine.ts');
+  const opponentEnsemble = [...ensemble.entries()].map(([key, policy]) => ({
+    split: key.startsWith('train:') ? 'train' as const : 'held-out' as const,
+    character: policy.character as OpponentName, policyId: policy.id, family: policy.family,
+    sourceHash: policy.sourceHash, config: policy.config, configHash: policy.configHash,
+  }));
+
+  return {
+    schema: LAB_SCHEMA,
+    engine: {
+      version: ENGINE_VERSION, commit: ENGINE_COMMIT,
+      engineSourceHash: hash(readFileSync(engineFile, 'utf8')),
+      exactEngine: true, networkAccess: false,
+    },
+    run: {
+      seed: checked.seed, trainSeeds: [...checked.trainSeeds], heldOutSeeds: [...checked.heldOutSeeds],
+      inputDelay: checked.inputDelay, opponents: [...DEFAULT_OPPONENTS], sideAssignments: ['a', 'b'],
+      candidateCount: candidateRows.length,
+    },
+    opponentEnsemble,
+    search: {
+      selectedPolicyId: selected.policyId, selectedConfig: selected.config, selectedConfigHash: selected.configHash,
+      candidates: candidateRows,
+      ...(checked.includeSearchMatches ? { matches: searchMatches } : {}),
+    },
+    evaluation: {
+      searched: evaluate(selectedPolicy),
+      frozenBaselines: [evaluate(frozenXenonBaseline()), evaluate(normalsBaseline())],
+    },
+    limitations: [
+      'Offline exact-engine outcomes do not establish live-network robustness or human-matchup strength.',
+      'Stages are pinned to dojo because stage art has no engine effect and live stage selection uses OS randomness.',
+      'The adversarial policies are fixed, mechanics-grounded heuristics; held-out families and seeds reduce but do not eliminate policy overfitting.',
+      `Policy source artifact SHA-256: ${hash(readFileSync(thisFile))}.`,
+    ],
+  };
+}
+
+function parseSeedList(value: string | undefined): number[] | undefined {
+  return value?.split(',').filter(Boolean).map(Number);
+}
+
+function parseArgs(argv: string[]): PolicyLabOptions & { pretty: boolean; help: boolean } {
+  const values: Record<string, string> = {};
+  let pretty = false, help = false, includeSearchMatches = false;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    if (arg === '--pretty') { pretty = true; continue; }
+    if (arg === '--include-search-matches') { includeSearchMatches = true; continue; }
+    if (arg === '--help' || arg === '-h') { help = true; continue; }
+    if (!arg.startsWith('--')) throw new Error(`unexpected argument: ${arg}`);
+    const value = argv[++i];
+    if (!value || value.startsWith('--')) throw new Error(`${arg} requires a value`);
+    values[arg.slice(2)] = value;
+  }
+  return {
+    seed: values.seed ? Number(values.seed) : undefined,
+    trainSeeds: parseSeedList(values['train-seeds']), heldOutSeeds: parseSeedList(values['held-out-seeds']),
+    inputDelay: values['input-delay'] ? Number(values['input-delay']) : undefined,
+    candidateLimit: values.candidates ? Number(values.candidates) : undefined,
+    includeSearchMatches, pretty, help,
+  };
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : '';
+if (import.meta.url === invokedPath) {
+  const parsed = parseArgs(process.argv.slice(2));
+  if (parsed.help) {
+    console.log(`Usage: pnpm policy:xenon [options]\n\nOptions:\n  --seed N                    run provenance seed\n  --train-seeds A,B,C         deterministic search/eval seeds\n  --held-out-seeds A,B,C      disjoint evaluation-only seeds\n  --input-delay N             action delay in frames (0-30)\n  --candidates N              bounded grid candidates (1-324)\n  --include-search-matches    include every search match in JSON\n  --pretty                    pretty-print JSON\n  --help                      show this help`);
+  } else {
+    const result = await runPolicyLab(parsed);
+    console.log(JSON.stringify(result, null, parsed.pretty ? 2 : 0));
+  }
+}

--- a/src/tools/xenon-policy-lab.ts
+++ b/src/tools/xenon-policy-lab.ts
@@ -139,11 +139,19 @@ export interface Aggregate {
   cleanKoWinRate: number;
   roundsWon: number;
   roundsLost: number;
+  koRoundsWon: number;
+  koRoundsLost: number;
+}
+
+export interface CandidateScore {
+  primaryCleanKoWins: number;
+  timeoutPenalty: number;
+  koRoundMargin: number;
 }
 
 export interface CandidateSummary extends Aggregate {
   rank?: number;
-  score: number;
+  score: CandidateScore;
   policyId: string;
   config: XenonConfig;
   configHash: string;
@@ -202,6 +210,10 @@ export interface PolicyLabResult {
     selectedPolicyId: string;
     selectedConfig: XenonConfig;
     selectedConfigHash: string;
+    scoring: {
+      ordering: string[];
+      note: string;
+    };
     candidates: CandidateSummary[];
     matches?: MatchResult[];
   };
@@ -547,12 +559,15 @@ function aggregate(matches: MatchResult[]): Aggregate {
   const cleanKoWins = matches.filter((m) => m.cleanKoWin).length;
   const timeoutWins = matches.filter((m) => m.terminal === 'time' && m.outcome === 'win').length;
   const timeoutLosses = matches.filter((m) => m.terminal === 'time' && m.outcome === 'loss').length;
+  const koMatches = matches.filter((m) => m.terminal === 'ko');
+  const koRoundsWon = koMatches.reduce((sum, m) => sum + m.rounds.executor, 0);
+  const koRoundsLost = koMatches.reduce((sum, m) => sum + m.rounds.opponent, 0);
   return {
     played: matches.length, wins, losses: matches.length - wins,
     koTerminals, cleanKoWins, timeoutWins, timeoutLosses,
     winRate: matches.length ? wins / matches.length : 0,
     cleanKoWinRate: matches.length ? cleanKoWins / matches.length : 0,
-    roundsWon, roundsLost,
+    roundsWon, roundsLost, koRoundsWon, koRoundsLost,
   };
 }
 
@@ -573,10 +588,22 @@ function scenarios(
   return results;
 }
 
-function score(summary: Aggregate): number {
-  // Search only on train scenarios. A frame-cap/non-terminal match throws, while
-  // timeout finals remain visible and are penalized rather than silently dropped.
-  return summary.wins * 1000 + (summary.roundsWon - summary.roundsLost) * 10 + summary.cleanKoWins;
+export function score(matches: readonly MatchResult[]): CandidateScore {
+  const koMatches = matches.filter((match) => match.terminal === 'ko');
+  return {
+    // Challenge objective: only executor wins ending in KO are primary evidence.
+    primaryCleanKoWins: koMatches.filter((match) => match.outcome === 'win').length,
+    // Every timeout is a penalty, including a timeout win. It contributes no
+    // clean-KO or round-margin credit.
+    timeoutPenalty: matches.filter((match) => match.terminal === 'time').length,
+    koRoundMargin: koMatches.reduce((margin, match) => margin + match.rounds.executor - match.rounds.opponent, 0),
+  };
+}
+
+function compareScore(a: CandidateScore, b: CandidateScore): number {
+  return b.primaryCleanKoWins - a.primaryCleanKoWins
+    || a.timeoutPenalty - b.timeoutPenalty
+    || b.koRoundMargin - a.koRoundMargin;
 }
 
 function validateOptions(options: PolicyLabOptions): Required<PolicyLabOptions> {
@@ -608,10 +635,10 @@ export async function runPolicyLab(options: PolicyLabOptions = {}): Promise<Poli
     const target = xenonPolicy(`xenon-search-${index.toString().padStart(3, '0')}`, 'searched-grid-v1', config);
     const matches = scenarios(target, 'train', checked.trainSeeds, checked.seed, checked.inputDelay, ensemble);
     const totals = aggregate(matches);
-    candidateRows.push({ ...totals, score: score(totals), policyId: target.id, config, configHash: target.configHash });
+    candidateRows.push({ ...totals, score: score(matches), policyId: target.id, config, configHash: target.configHash });
     if (checked.includeSearchMatches) searchMatches.push(...matches);
   }
-  candidateRows.sort((a, b) => b.score - a.score || a.configHash.localeCompare(b.configHash));
+  candidateRows.sort((a, b) => compareScore(a.score, b.score) || a.configHash.localeCompare(b.configHash));
   candidateRows.forEach((row, index) => { row.rank = index + 1; });
   const selected = candidateRows[0]!;
   const selectedPolicy = xenonPolicy(selected.policyId, 'searched-grid-v1', selected.config);
@@ -653,6 +680,10 @@ export async function runPolicyLab(options: PolicyLabOptions = {}): Promise<Poli
     opponentEnsemble,
     search: {
       selectedPolicyId: selected.policyId, selectedConfig: selected.config, selectedConfigHash: selected.configHash,
+      scoring: {
+        ordering: ['cleanKoWins descending', 'timeoutPenalty ascending', 'KO-terminal round margin descending', 'configHash ascending'],
+        note: 'Timeout wins remain descriptive wins but receive zero primary or round-margin credit and one timeout penalty.',
+      },
       candidates: candidateRows,
       ...(checked.includeSearchMatches ? { matches: searchMatches } : {}),
     },

--- a/src/xenon-policy-lab-test.ts
+++ b/src/xenon-policy-lab-test.ts
@@ -1,4 +1,4 @@
-import { runPolicyLab, validateMechanicsSnapshot, ENGINE_COMMIT, EXPECTED_MECHANICS_HASH, LAB_SCHEMA } from './tools/xenon-policy-lab.js';
+import { runPolicyLab, score, validateMechanicsSnapshot, ENGINE_COMMIT, EXPECTED_MECHANICS_HASH, LAB_SCHEMA } from './tools/xenon-policy-lab.js';
 
 let pass = true;
 const check = (name: string, ok: boolean, detail = ''): void => {
@@ -88,8 +88,24 @@ check('aggregate clean-KO and timeout fields are executor-relative and unambiguo
       && aggregate.cleanKoWins === matches.filter((m) => m.outcome === 'win' && m.terminal === 'ko').length
       && aggregate.timeoutWins === matches.filter((m) => m.outcome === 'win' && m.terminal === 'time').length
       && aggregate.timeoutLosses === matches.filter((m) => m.outcome === 'loss' && m.terminal === 'time').length
-      && aggregate.cleanKoWinRate === aggregate.cleanKoWins / aggregate.played;
+      && aggregate.cleanKoWinRate === aggregate.cleanKoWins / aggregate.played
+      && aggregate.koRoundsWon === matches.filter((m) => m.terminal === 'ko').reduce((sum, m) => sum + m.rounds.executor, 0)
+      && aggregate.koRoundsLost === matches.filter((m) => m.terminal === 'ko').reduce((sum, m) => sum + m.rounds.opponent, 0);
   })));
+const timeoutFixture = await runPolicyLab({ ...options, inputDelay: 0, candidateLimit: 1, includeSearchMatches: false });
+const timeoutWin = [timeoutFixture.evaluation.searched, ...timeoutFixture.evaluation.frozenBaselines]
+  .flatMap((block) => block.matches).find((m) => m.outcome === 'win' && m.terminal === 'time');
+const timeoutOnlyScore = timeoutWin ? score([timeoutWin]) : null;
+check('a timeout win has zero primary and round-margin credit plus one penalty',
+  !!timeoutWin && !timeoutWin.cleanKoWin
+    && timeoutOnlyScore?.primaryCleanKoWins === 0
+    && timeoutOnlyScore.koRoundMargin === 0
+    && timeoutOnlyScore.timeoutPenalty === 1);
+check('reported candidate scoring declares clean-KO-first timeout-penalized ordering',
+  first.search.scoring.ordering.join('|') === 'cleanKoWins descending|timeoutPenalty ascending|KO-terminal round margin descending|configHash ascending'
+    && first.search.candidates.every((candidate) => candidate.score.primaryCleanKoWins === candidate.cleanKoWins
+      && candidate.score.timeoutPenalty === candidate.timeoutWins + candidate.timeoutLosses
+      && candidate.score.koRoundMargin === candidate.koRoundsWon - candidate.koRoundsLost));
 
 let overlapRejected = false;
 try { await runPolicyLab({ trainSeeds: [1], heldOutSeeds: [1], candidateLimit: 1 }); } catch { overlapRejected = true; }

--- a/src/xenon-policy-lab-test.ts
+++ b/src/xenon-policy-lab-test.ts
@@ -1,4 +1,4 @@
-import { runPolicyLab, ENGINE_COMMIT, LAB_SCHEMA } from './tools/xenon-policy-lab.js';
+import { runPolicyLab, validateMechanicsSnapshot, ENGINE_COMMIT, EXPECTED_MECHANICS_HASH, LAB_SCHEMA } from './tools/xenon-policy-lab.js';
 
 let pass = true;
 const check = (name: string, ok: boolean, detail = ''): void => {
@@ -12,19 +12,40 @@ const options = {
   heldOutSeeds: [401],
   inputDelay: 2,
   candidateLimit: 2,
+  includeSearchMatches: true,
 };
 const first = await runPolicyLab(options);
 const second = await runPolicyLab(options);
 
 check('same configuration is byte-for-byte deterministic', JSON.stringify(first) === JSON.stringify(second));
 check('provenance pins exact engine commit and offline execution',
-  first.schema === LAB_SCHEMA && first.engine.commit === ENGINE_COMMIT && first.engine.exactEngine && !first.engine.networkAccess);
+  first.schema === LAB_SCHEMA && first.engine.expectedBaseCommit === ENGINE_COMMIT
+    && first.engine.mechanicsHash === EXPECTED_MECHANICS_HASH && first.engine.mechanicsValidated
+    && first.engine.mechanicsFiles.join(',') === 'src/game/engine.ts,src/game/moves.ts,src/game/types.ts'
+    && !first.engine.networkAccess);
+let mechanicsMismatchRejected = false, versionMismatchRejected = false;
+try { validateMechanicsSnapshot('0'.repeat(64)); } catch { mechanicsMismatchRejected = true; }
+try { validateMechanicsSnapshot(EXPECTED_MECHANICS_HASH, 'sf-future'); } catch { versionMismatchRejected = true; }
+check('mechanics provenance fails closed on source or version drift', mechanicsMismatchRejected && versionMismatchRejected);
 check('ensemble covers four current-mechanics fighters in train and held-out families',
   first.opponentEnsemble.length === 8
     && new Set(first.opponentEnsemble.map((p) => p.character)).size === 4
     && new Set(first.opponentEnsemble.map((p) => p.family)).size === 2);
 check('search is bounded and hashes every configuration',
   first.search.candidates.length === 2 && first.search.candidates.every((c) => /^[0-9a-f]{64}$/.test(c.configHash)));
+
+const searchedMatches = first.search.matches ?? [];
+const seedTuple = (m: typeof searchedMatches[number]): string =>
+  `${m.streamRootSeed}|${m.matchSeed}|${m.targetPolicySeed}|${m.opponentPolicySeed}`;
+check('candidate configs and paired seats share common random-number streams',
+  searchedMatches.length === 16 && ['OMEGA', 'MNEME', 'AJAX', 'FABLE'].every((opponent) => {
+    const scenario = searchedMatches.filter((m) => m.opponent === opponent && m.scenarioSeed === 101);
+    return scenario.length === 4
+      && new Set(scenario.map((m) => m.targetConfigHash)).size === 2
+      && new Set(scenario.map(seedTuple)).size === 1
+      && new Set(scenario.map((m) => m.executorSide)).size === 2
+      && new Set(scenario.map((m) => m.id)).size === 4;
+  }));
 
 const blocks = [first.evaluation.searched, ...first.evaluation.frozenBaselines];
 check('searched policy is compared with two frozen baselines', first.evaluation.frozenBaselines.length === 2);
@@ -38,9 +59,26 @@ check('every block evaluates disjoint train/held-out seeds on both sides', block
     && held.every((m) => m.inputDelay === 2 && m.scenarioSeed === 401 && m.matchSeed !== m.scenarioSeed)
     && block.matches.every((m) => m.targetPolicySeed !== m.opponentPolicySeed);
 }));
+check('paired seats and frozen/selected policies preserve the same scenario streams',
+  ['train', 'held-out'].every((split) => ['OMEGA', 'MNEME', 'AJAX', 'FABLE'].every((opponent) => {
+    const scenario = blocks.flatMap((block) => block.matches).filter((m) => m.split === split && m.opponent === opponent);
+    return scenario.length === 6 && new Set(scenario.map(seedTuple)).size === 1;
+  })));
+check('train/held-out and target/opponent streams remain disjoint',
+  blocks.every((block) => {
+    const trainSeeds = new Set(block.matches.filter((m) => m.split === 'train').flatMap((m) => [m.matchSeed, m.targetPolicySeed, m.opponentPolicySeed]));
+    const heldSeeds = block.matches.filter((m) => m.split === 'held-out').flatMap((m) => [m.matchSeed, m.targetPolicySeed, m.opponentPolicySeed]);
+    return heldSeeds.every((seed) => !trainSeeds.has(seed))
+      && block.matches.every((m) => new Set([m.matchSeed, m.targetPolicySeed, m.opponentPolicySeed]).size === 3);
+  }));
 check('all results are authoritative whole matches with explicit terminal evidence', blocks.every((block) =>
   block.matches.every((m) => m.rounds.executor === 2 || m.rounds.opponent === 2)
     && block.matches.every((m) => m.terminal !== 'frame-cap' && m.roundTerminals.length >= 2)));
+const evaluatedMatches = blocks.flatMap((block) => block.matches);
+check('clean-KO evidence excludes time decisions',
+  evaluatedMatches.every((m) => m.cleanKo === (m.terminal === 'ko'))
+    && blocks.every((block) => block.train.cleanKos === block.matches.filter((m) => m.split === 'train' && m.terminal === 'ko').length
+      && block.heldOut.cleanKos === block.matches.filter((m) => m.split === 'held-out' && m.terminal === 'ko').length));
 
 let overlapRejected = false;
 try { await runPolicyLab({ trainSeeds: [1], heldOutSeeds: [1], candidateLimit: 1 }); } catch { overlapRejected = true; }

--- a/src/xenon-policy-lab-test.ts
+++ b/src/xenon-policy-lab-test.ts
@@ -1,0 +1,50 @@
+import { runPolicyLab, ENGINE_COMMIT, LAB_SCHEMA } from './tools/xenon-policy-lab.js';
+
+let pass = true;
+const check = (name: string, ok: boolean, detail = ''): void => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? `  ${detail}` : ''}`);
+  if (!ok) pass = false;
+};
+
+const options = {
+  seed: 17,
+  trainSeeds: [101],
+  heldOutSeeds: [401],
+  inputDelay: 2,
+  candidateLimit: 2,
+};
+const first = await runPolicyLab(options);
+const second = await runPolicyLab(options);
+
+check('same configuration is byte-for-byte deterministic', JSON.stringify(first) === JSON.stringify(second));
+check('provenance pins exact engine commit and offline execution',
+  first.schema === LAB_SCHEMA && first.engine.commit === ENGINE_COMMIT && first.engine.exactEngine && !first.engine.networkAccess);
+check('ensemble covers four current-mechanics fighters in train and held-out families',
+  first.opponentEnsemble.length === 8
+    && new Set(first.opponentEnsemble.map((p) => p.character)).size === 4
+    && new Set(first.opponentEnsemble.map((p) => p.family)).size === 2);
+check('search is bounded and hashes every configuration',
+  first.search.candidates.length === 2 && first.search.candidates.every((c) => /^[0-9a-f]{64}$/.test(c.configHash)));
+
+const blocks = [first.evaluation.searched, ...first.evaluation.frozenBaselines];
+check('searched policy is compared with two frozen baselines', first.evaluation.frozenBaselines.length === 2);
+check('every block evaluates disjoint train/held-out seeds on both sides', blocks.every((block) => {
+  const train = block.matches.filter((m) => m.split === 'train');
+  const held = block.matches.filter((m) => m.split === 'held-out');
+  return train.length === 8 && held.length === 8
+    && new Set(train.map((m) => m.executorSide)).size === 2
+    && new Set(held.map((m) => m.executorSide)).size === 2
+    && train.every((m) => m.inputDelay === 2 && m.scenarioSeed === 101 && m.matchSeed !== m.scenarioSeed)
+    && held.every((m) => m.inputDelay === 2 && m.scenarioSeed === 401 && m.matchSeed !== m.scenarioSeed)
+    && block.matches.every((m) => m.targetPolicySeed !== m.opponentPolicySeed);
+}));
+check('all results are authoritative whole matches with explicit terminal evidence', blocks.every((block) =>
+  block.matches.every((m) => m.rounds.executor === 2 || m.rounds.opponent === 2)
+    && block.matches.every((m) => m.terminal !== 'frame-cap' && m.roundTerminals.length >= 2)));
+
+let overlapRejected = false;
+try { await runPolicyLab({ trainSeeds: [1], heldOutSeeds: [1], candidateLimit: 1 }); } catch { overlapRejected = true; }
+check('overlapping train/held-out seeds fail fast', overlapRejected);
+
+console.log(pass ? '\nXENON POLICY LAB TEST: PASS' : '\nXENON POLICY LAB TEST: FAIL');
+process.exit(pass ? 0 : 1);

--- a/src/xenon-policy-lab-test.ts
+++ b/src/xenon-policy-lab-test.ts
@@ -75,10 +75,21 @@ check('all results are authoritative whole matches with explicit terminal eviden
   block.matches.every((m) => m.rounds.executor === 2 || m.rounds.opponent === 2)
     && block.matches.every((m) => m.terminal !== 'frame-cap' && m.roundTerminals.length >= 2)));
 const evaluatedMatches = blocks.flatMap((block) => block.matches);
-check('clean-KO evidence excludes time decisions',
-  evaluatedMatches.every((m) => m.cleanKo === (m.terminal === 'ko'))
-    && blocks.every((block) => block.train.cleanKos === block.matches.filter((m) => m.split === 'train' && m.terminal === 'ko').length
-      && block.heldOut.cleanKos === block.matches.filter((m) => m.split === 'held-out' && m.terminal === 'ko').length));
+const losingKos = evaluatedMatches.filter((m) => m.outcome === 'loss' && m.terminal === 'ko');
+check('KO terminal provenance is distinct from executor clean-KO wins',
+  losingKos.length > 0 && losingKos.every((m) => m.koTerminal && !m.cleanKoWin)
+    && evaluatedMatches.every((m) => m.koTerminal === (m.terminal === 'ko'))
+    && evaluatedMatches.every((m) => m.cleanKoWin === (m.outcome === 'win' && m.terminal === 'ko')));
+check('aggregate clean-KO and timeout fields are executor-relative and unambiguous', blocks.every((block) =>
+  (['train', 'held-out'] as const).every((split) => {
+    const matches = block.matches.filter((m) => m.split === split);
+    const aggregate = block[split === 'train' ? 'train' : 'heldOut'];
+    return aggregate.koTerminals === matches.filter((m) => m.terminal === 'ko').length
+      && aggregate.cleanKoWins === matches.filter((m) => m.outcome === 'win' && m.terminal === 'ko').length
+      && aggregate.timeoutWins === matches.filter((m) => m.outcome === 'win' && m.terminal === 'time').length
+      && aggregate.timeoutLosses === matches.filter((m) => m.outcome === 'loss' && m.terminal === 'time').length
+      && aggregate.cleanKoWinRate === aggregate.cleanKoWins / aggregate.played;
+  })));
 
 let overlapRejected = false;
 try { await runPolicyLab({ trainSeeds: [1], heldOutSeeds: [1], candidateLimit: 1 }); } catch { overlapRejected = true; }


### PR DESCRIPTION
## What changed

- add an offline-only exact-engine XENON policy search and evaluation lab
- evaluate current-mechanics OMEGA, MNEME, AJAX, and FABLE opponent families
- separate train and held-out opponent policies and scenario seeds
- pair both side assignments with common random-number streams
- support deterministic input-delay stress, frozen baselines, and machine-readable whole-match evidence
- bind results to fail-closed `sf-6` mechanics provenance and policy/config hashes

## Why

Live match volume confounds character strength, controller policy, seat, network delay, and opponent composition. This harness searches policy parameters against the exact current engine without changing combat mechanics or connecting to the live arena. Its outputs are offline evidence only; they are not claims of live or human-opponent performance.

## Experimental safeguards

- opponent RNG streams are independent of candidate configuration and seat
- train/held-out and engine/target/opponent RNG roles are disjoint
- selection is lexicographic: executor clean-KO wins, fewer timeouts, KO-terminal-only round margin, deterministic config hash
- timeout wins receive zero clean-KO and round-margin credit and incur one timeout penalty
- KO losses remain terminal evidence but never count as executor clean-KO wins
- result IDs retain configuration, side, delay, opponent, and seed identity
- mechanics provenance validates `sf-6` plus the reviewed `engine.ts`, `moves.ts`, and `types.ts` snapshot before a run
- only raw engine state is used; known-stale bot convenience flags are not inputs

## Validation

- independent exact-head review approved `3189a03342cb87ac41eeb6832dfd093ec4654f53`
- executable engine-produced timeout-win and losing-KO regressions passed
- focused policy-lab tests passed
- typecheck and every full-suite constituent passed
- default run produced 1,152 unique result IDs for 1,152 searched matches with shared candidate/seat RNG streams
- `git diff --check` passed

No engine changes, network calls, live matches, queue operations, or deployment are included.

Draft intentionally: keep this out of unattended merge automation until GitHub CI on the reviewed exact head is complete.
