### PR TITLE
chore: preserve XENON latency trace experiment

### DIFF
--- a/src/tools/xenon-policy-lab.ts
+++ b/src/tools/xenon-policy-lab.ts
@@ -42,6 +42,7 @@ type OpponentName = typeof DEFAULT_OPPONENTS[number];
 export interface DelayScenario { targetDelay: number; opponentDelay: number; }
 
 export interface RawFighterObservation {
+  name: string;
   x: number;
   y: number;
   vx: number;
@@ -300,6 +301,7 @@ function deriveSeed(...parts: Array<number | string>): number {
 
 function raw(fighter: Fighter): RawFighterObservation {
   return {
+    name: fighter.name,
     x: fighter.x, y: fighter.y, vx: fighter.vx, vy: fighter.vy,
     facing: fighter.facing, hp: fighter.hp, wins: fighter.wins,
     attack: fighter.attack, attackFrame: fighter.attackFrame, stun: fighter.stun,
@@ -432,10 +434,28 @@ function xenonPolicy(id: string, family: string, config: XenonConfig): PolicyDef
       const opponentCommitted = context.opponent.attack !== 'none';
 
       if (incomingProjectile(context, config.projectileReflectDistance))
-        return special('XENON', 'reflect', context.self.facing);
+        return special('XENON', context.opponent.name === 'MNEME' ? 'phase' : 'reflect', context.self.facing);
+      // Throwaway latency counterfactual: never request a grounded special while
+      // airborne, and pre-commit PHASE inside the five-frame danger envelope.
+      if (context.self.y > 3 && (context.opponent.name === 'MNEME' || context.opponent.name === 'FABLE'))
+        return dist <= 48 ? move(dir, { kick: true }) : move(dir);
+      if (context.opponent.name === 'MNEME') {
+        if (context.opponent.attack === 'construct' || context.opponent.attack === 'volley')
+          return special('XENON', 'phase', context.self.facing);
+        if (context.opponent.attack === 'nova') {
+          return context.opponent.attackFrame >= 10
+            ? special('XENON', 'blink', context.self.facing)
+            : move(away, { down: true });
+        }
+        if (context.opponent.attack !== 'none' && context.opponent.attackFrame <= 1 && dist <= 68)
+          return special('XENON', 'phase', context.self.facing);
+        return move(away, { down: true });
+      }
       if (opponentCommitted && context.opponent.attackFrame <= 8 && dist <= config.phaseThreatDistance)
         return special('XENON', 'phase', context.self.facing);
       if (context.self.y > 3) return dist <= 48 ? move(dir, { kick: true }) : move(dir);
+      if (context.opponent.name === 'FABLE' && dist <= 68)
+        return special('XENON', 'phase', context.self.facing);
       if (dist >= config.blinkDistance) return special('XENON', 'blink', context.self.facing);
       if (dist >= config.phaseNeutralDistance) return special('XENON', 'phase', context.self.facing);
       if (dist <= 27) return random() < config.closeThrowChance ? move(0, { throw: true }) : move(0, { kick: true });
@@ -474,6 +494,14 @@ function frozenXenonBaseline(): PolicyDefinition {
 }
 
 function candidateConfigs(limit: number): XenonConfig[] {
+  if (process.env.XENON_TRACE_SELECTED === '1') return [{
+    projectileReflectDistance: 68,
+    phaseThreatDistance: 68,
+    phaseNeutralDistance: 76,
+    blinkDistance: 72,
+    closeThrowChance: 0.5,
+    jumpKickChance: 0.12,
+  }];
   const configs: XenonConfig[] = [];
   for (const projectileReflectDistance of [44, 68, 92])
     for (const phaseThreatDistance of [42, 54, 68])
@@ -545,7 +573,37 @@ function playMatch(
     };
     const intendedA = executorSide === 'a' ? targetInstance.decide(contextA) : opponentInstance.decide(contextA);
     const intendedB = executorSide === 'b' ? targetInstance.decide(contextB) : opponentInstance.decide(contextB);
-    stepMatch(match, delayA.push(intendedA), delayB.push(intendedB));
+    const appliedA = delayA.push(intendedA);
+    const appliedB = delayB.push(intendedB);
+    const traceThis = process.env.XENON_TRACE === '1'
+      && process.env.XENON_TRACE_OPPONENT === opponent.character
+      && Number(process.env.XENON_TRACE_TARGET_DELAY) === delayScenario.targetDelay
+      && Number(process.env.XENON_TRACE_OPPONENT_DELAY) === delayScenario.opponentDelay
+      && Number(process.env.XENON_TRACE_SEED) === seed
+      && process.env.XENON_TRACE_SIDE === executorSide
+      && process.env.XENON_TRACE_SPLIT === split;
+    const beforeA = traceThis ? raw(match.a) : null;
+    const beforeB = traceThis ? raw(match.b) : null;
+    const beforeProjectiles = traceThis ? projectileView(match.projectiles, executorSide) : null;
+    stepMatch(match, appliedA, appliedB);
+    if (traceThis && (previousPhase === 'fight' || match.phase === 'fight')) {
+      const targetBefore = executorSide === 'a' ? beforeA : beforeB;
+      const opponentBefore = executorSide === 'a' ? beforeB : beforeA;
+      const targetAfter = raw(executorSide === 'a' ? match.a : match.b);
+      const opponentAfter = raw(executorSide === 'a' ? match.b : match.a);
+      console.error(JSON.stringify({
+        kind: 'trace', split, seed, executorSide, opponent: opponent.character,
+        targetDelay: delayScenario.targetDelay, opponentDelay: delayScenario.opponentDelay,
+        frame: match.frame, round: match.round, phaseBefore: previousPhase, phaseAfter: match.phase,
+        targetBefore, opponentBefore, targetAfter, opponentAfter,
+        intendedTarget: executorSide === 'a' ? intendedA : intendedB,
+        appliedTarget: executorSide === 'a' ? appliedA : appliedB,
+        intendedOpponent: executorSide === 'a' ? intendedB : intendedA,
+        appliedOpponent: executorSide === 'a' ? appliedB : appliedA,
+        projectilesBefore: beforeProjectiles,
+        projectilesAfter: projectileView(match.projectiles, executorSide),
+      }));
+    }
 
     const currentPhase = match.phase as MatchPhase; // stepMatch mutates through the shared Match object.
     if (previousPhase === 'fight' && (currentPhase === 'round-over' || currentPhase === 'match-over')) {

--- a/src/tools/xenon-policy-lab.ts
+++ b/src/tools/xenon-policy-lab.ts
@@ -24,7 +24,11 @@ const MECHANICS_FILES = ['game/engine.ts', 'game/moves.ts', 'game/types.ts'] as 
 const POLICY_SOURCE_VERSION = 'xenon-policy-lab-policies/v1';
 const DEFAULT_TRAIN_SEEDS = [101, 211, 307];
 const DEFAULT_HELD_OUT_SEEDS = [401, 503, 607];
-const DEFAULT_INPUT_DELAYS = [0, 2, 5];
+const DEFAULT_DELAY_SCENARIOS: DelayScenario[] = [
+  { targetDelay: 0, opponentDelay: 0 }, { targetDelay: 2, opponentDelay: 0 },
+  { targetDelay: 5, opponentDelay: 0 }, { targetDelay: 0, opponentDelay: 2 },
+  { targetDelay: 2, opponentDelay: 2 }, { targetDelay: 5, opponentDelay: 2 },
+];
 const DEFAULT_OPPONENTS = ['OMEGA', 'MNEME', 'AJAX', 'FABLE'] as const;
 // Three full 60-second rounds plus countdown/inter-round ceremony fit below this
 // cap. Reaching it is an error, never a draw silently folded into evaluation.
@@ -34,6 +38,8 @@ type Side = 'a' | 'b';
 type Split = 'train' | 'held-out';
 type Outcome = 'win' | 'loss';
 type OpponentName = typeof DEFAULT_OPPONENTS[number];
+
+export interface DelayScenario { targetDelay: number; opponentDelay: number; }
 
 export interface RawFighterObservation {
   x: number;
@@ -116,7 +122,8 @@ export interface MatchResult {
   opponentConfigHash: string;
   targetPolicy: string;
   targetConfigHash: string;
-  inputDelay: number;
+  delayScenario: DelayScenario;
+  seatDelays: { a: number; b: number };
   stage: string;
   frames: number;
   rounds: { executor: number; opponent: number };
@@ -151,12 +158,12 @@ export interface CandidateScore {
 }
 
 export interface RobustCandidateScore {
-  worstDelayCleanKoWins: number;
+  worstScenarioCleanKoWins: number;
   totalCleanKoWins: number;
   totalTimeoutPenalty: number;
-  worstDelayKoRoundMargin: number;
+  worstScenarioKoRoundMargin: number;
   totalKoRoundMargin: number;
-  byDelay: Array<{ inputDelay: number; evidence: CandidateScore }>;
+  byScenario: Array<{ scenario: DelayScenario; evidence: CandidateScore }>;
 }
 
 export interface CandidateSummary extends Aggregate {
@@ -174,7 +181,7 @@ export interface EvaluationBlock {
   configHash: string;
   train: Aggregate;
   heldOut: Aggregate;
-  byDelay: Array<{ inputDelay: number; train: Aggregate; heldOut: Aggregate }>;
+  byScenario: Array<{ scenario: DelayScenario; train: Aggregate; heldOut: Aggregate }>;
   matches: MatchResult[];
 }
 
@@ -182,7 +189,7 @@ export interface PolicyLabOptions {
   seed?: number;
   trainSeeds?: number[];
   heldOutSeeds?: number[];
-  inputDelays?: number[];
+  delayScenarios?: DelayScenario[];
   candidateLimit?: number;
   includeSearchMatches?: boolean;
 }
@@ -204,7 +211,7 @@ export interface PolicyLabResult {
     seed: number;
     trainSeeds: number[];
     heldOutSeeds: number[];
-    inputDelays: number[];
+    delayScenarios: DelayScenario[];
     opponents: OpponentName[];
     sideAssignments: Side[];
     candidateCount: number;
@@ -488,6 +495,12 @@ class InputDelay {
   }
 }
 
+export function delaysBySeat(scenario: DelayScenario, executorSide: Side): { a: number; b: number } {
+  return executorSide === 'a'
+    ? { a: scenario.targetDelay, b: scenario.opponentDelay }
+    : { a: scenario.opponentDelay, b: scenario.targetDelay };
+}
+
 function playMatch(
   target: PolicyDefinition,
   opponent: PolicyDefinition,
@@ -495,7 +508,7 @@ function playMatch(
   executorSide: Side,
   runSeed: number,
   seed: number,
-  inputDelay: number,
+  delayScenario: DelayScenario,
 ): MatchResult {
   // Common-random-number design: every candidate and both seat assignments see
   // the same stochastic streams for a given split/opponent/scenario. Candidate
@@ -511,8 +524,9 @@ function playMatch(
   const bCharacter = executorSide === 'b' ? 'XENON' : opponent.character;
   const match = makeMatch(makeFighter('a', aCharacter, 'a'), makeFighter('b', bCharacter, 'b'));
   match.stage = 'dojo'; // stages are cosmetic; pin one to eliminate OS-CSPRNG provenance noise.
-  const delayA = new InputDelay(inputDelay);
-  const delayB = new InputDelay(inputDelay);
+  const seatDelays = delaysBySeat(delayScenario, executorSide);
+  const delayA = new InputDelay(seatDelays.a);
+  const delayB = new InputDelay(seatDelays.b);
   const roundTerminals: RoundTerminal[] = [];
   let previousPhase: MatchPhase = match.phase;
 
@@ -549,11 +563,11 @@ function playMatch(
   const last = roundTerminals.at(-1);
   const terminal = last?.reason ?? 'frame-cap';
   return {
-    id: hash(`${matchSeed}|${target.id}|${target.configHash}|${opponent.id}|${executorSide}|${inputDelay}`).slice(0, 16), split,
+    id: hash(`${matchSeed}|${target.id}|${target.configHash}|${opponent.id}|${executorSide}|${delayScenario.targetDelay}:${delayScenario.opponentDelay}`).slice(0, 16), split,
     scenarioSeed: seed, streamRootSeed, matchSeed, targetPolicySeed, opponentPolicySeed,
     executorSide, executor: 'XENON', opponent: opponent.character as OpponentName,
     opponentPolicy: opponent.id, opponentFamily: opponent.family, opponentConfigHash: opponent.configHash,
-    targetPolicy: target.id, targetConfigHash: target.configHash, inputDelay, stage: match.stage,
+    targetPolicy: target.id, targetConfigHash: target.configHash, delayScenario: { ...delayScenario }, seatDelays, stage: match.stage,
     frames: match.frame,
     rounds: { executor: executorSide === 'a' ? match.a.wins : match.b.wins, opponent: executorSide === 'a' ? match.b.wins : match.a.wins },
     winner: executorWins ? 'executor' : 'opponent', outcome: executorWins ? 'win' : 'loss',
@@ -588,14 +602,14 @@ function scenarios(
   split: Split,
   seeds: number[],
   runSeed: number,
-  inputDelays: number[],
+  delayScenarios: DelayScenario[],
   ensemble: Map<string, PolicyDefinition>,
 ): MatchResult[] {
   const results: MatchResult[] = [];
-  for (const inputDelay of inputDelays) for (const opponentName of DEFAULT_OPPONENTS) {
+  for (const delayScenario of delayScenarios) for (const opponentName of DEFAULT_OPPONENTS) {
     const opponent = ensemble.get(`${split}:${opponentName}`)!;
     for (const seed of seeds) for (const side of ['a', 'b'] as const)
-      results.push(playMatch(target, opponent, split, side, runSeed, seed, inputDelay));
+      results.push(playMatch(target, opponent, split, side, runSeed, seed, delayScenario));
   }
   return results;
 }
@@ -612,26 +626,28 @@ export function score(matches: readonly MatchResult[]): CandidateScore {
   };
 }
 
-function robustScore(matches: readonly MatchResult[], inputDelays: readonly number[]): RobustCandidateScore {
-  const byDelay = inputDelays.map((inputDelay) => ({
-    inputDelay,
-    evidence: score(matches.filter((match) => match.inputDelay === inputDelay)),
+const scenarioKey = (scenario: DelayScenario): string => `${scenario.targetDelay}:${scenario.opponentDelay}`;
+
+function robustScore(matches: readonly MatchResult[], delayScenarios: readonly DelayScenario[]): RobustCandidateScore {
+  const byScenario = delayScenarios.map((scenario) => ({
+    scenario: { ...scenario },
+    evidence: score(matches.filter((match) => scenarioKey(match.delayScenario) === scenarioKey(scenario))),
   }));
   return {
-    worstDelayCleanKoWins: Math.min(...byDelay.map((row) => row.evidence.primaryCleanKoWins)),
-    totalCleanKoWins: byDelay.reduce((sum, row) => sum + row.evidence.primaryCleanKoWins, 0),
-    totalTimeoutPenalty: byDelay.reduce((sum, row) => sum + row.evidence.timeoutPenalty, 0),
-    worstDelayKoRoundMargin: Math.min(...byDelay.map((row) => row.evidence.koRoundMargin)),
-    totalKoRoundMargin: byDelay.reduce((sum, row) => sum + row.evidence.koRoundMargin, 0),
-    byDelay,
+    worstScenarioCleanKoWins: Math.min(...byScenario.map((row) => row.evidence.primaryCleanKoWins)),
+    totalCleanKoWins: byScenario.reduce((sum, row) => sum + row.evidence.primaryCleanKoWins, 0),
+    totalTimeoutPenalty: byScenario.reduce((sum, row) => sum + row.evidence.timeoutPenalty, 0),
+    worstScenarioKoRoundMargin: Math.min(...byScenario.map((row) => row.evidence.koRoundMargin)),
+    totalKoRoundMargin: byScenario.reduce((sum, row) => sum + row.evidence.koRoundMargin, 0),
+    byScenario,
   };
 }
 
 function compareRobustScore(a: RobustCandidateScore, b: RobustCandidateScore): number {
-  return b.worstDelayCleanKoWins - a.worstDelayCleanKoWins
+  return b.worstScenarioCleanKoWins - a.worstScenarioCleanKoWins
     || b.totalCleanKoWins - a.totalCleanKoWins
     || a.totalTimeoutPenalty - b.totalTimeoutPenalty
-    || b.worstDelayKoRoundMargin - a.worstDelayKoRoundMargin
+    || b.worstScenarioKoRoundMargin - a.worstScenarioKoRoundMargin
     || b.totalKoRoundMargin - a.totalKoRoundMargin;
 }
 
@@ -639,17 +655,19 @@ function validateOptions(options: PolicyLabOptions): Required<PolicyLabOptions> 
   const seed = options.seed ?? 1;
   const trainSeeds = options.trainSeeds ?? DEFAULT_TRAIN_SEEDS;
   const heldOutSeeds = options.heldOutSeeds ?? DEFAULT_HELD_OUT_SEEDS;
-  const inputDelays = options.inputDelays ?? DEFAULT_INPUT_DELAYS;
+  const delayScenarios = options.delayScenarios ?? DEFAULT_DELAY_SCENARIOS;
   const candidateLimit = options.candidateLimit ?? 48;
   if (!Number.isInteger(seed)) throw new Error('seed must be an integer');
   if (!trainSeeds.length || !heldOutSeeds.length || [...trainSeeds, ...heldOutSeeds].some((s) => !Number.isInteger(s)))
     throw new Error('train and held-out seeds must be non-empty integer lists');
   if (trainSeeds.some((s) => heldOutSeeds.includes(s))) throw new Error('train and held-out seeds must be disjoint');
-  if (!inputDelays.length || inputDelays.some((delay) => !Number.isInteger(delay) || delay < 0 || delay > 30))
-    throw new Error('inputDelays must be a non-empty list of integers from 0 to 30');
-  if (new Set(inputDelays).size !== inputDelays.length) throw new Error('inputDelays must be unique');
+  if (!delayScenarios.length || delayScenarios.some(({ targetDelay, opponentDelay }) =>
+    !Number.isInteger(targetDelay) || targetDelay < 0 || targetDelay > 30
+    || !Number.isInteger(opponentDelay) || opponentDelay < 0 || opponentDelay > 30))
+    throw new Error('delayScenarios must contain target/opponent integer delays from 0 to 30');
+  if (new Set(delayScenarios.map(scenarioKey)).size !== delayScenarios.length) throw new Error('delayScenarios must be unique');
   if (!Number.isInteger(candidateLimit) || candidateLimit < 1 || candidateLimit > 324) throw new Error('candidateLimit must be an integer from 1 to 324');
-  return { seed, trainSeeds, heldOutSeeds, inputDelays: [...inputDelays], candidateLimit, includeSearchMatches: options.includeSearchMatches ?? false };
+  return { seed, trainSeeds, heldOutSeeds, delayScenarios: delayScenarios.map((scenario) => ({ ...scenario })), candidateLimit, includeSearchMatches: options.includeSearchMatches ?? false };
 }
 
 export async function runPolicyLab(options: PolicyLabOptions = {}): Promise<PolicyLabResult> {
@@ -664,9 +682,9 @@ export async function runPolicyLab(options: PolicyLabOptions = {}): Promise<Poli
   const searchMatches: MatchResult[] = [];
   for (const [index, config] of candidateConfigs(checked.candidateLimit).entries()) {
     const target = xenonPolicy(`xenon-search-${index.toString().padStart(3, '0')}`, 'searched-grid-v1', config);
-    const matches = scenarios(target, 'train', checked.trainSeeds, checked.seed, checked.inputDelays, ensemble);
+    const matches = scenarios(target, 'train', checked.trainSeeds, checked.seed, checked.delayScenarios, ensemble);
     const totals = aggregate(matches);
-    candidateRows.push({ ...totals, score: robustScore(matches, checked.inputDelays), policyId: target.id, config, configHash: target.configHash });
+    candidateRows.push({ ...totals, score: robustScore(matches, checked.delayScenarios), policyId: target.id, config, configHash: target.configHash });
     if (checked.includeSearchMatches) searchMatches.push(...matches);
   }
   candidateRows.sort((a, b) => compareRobustScore(a.score, b.score) || a.configHash.localeCompare(b.configHash));
@@ -676,17 +694,17 @@ export async function runPolicyLab(options: PolicyLabOptions = {}): Promise<Poli
 
   const evaluate = (policy: PolicyDefinition): EvaluationBlock => {
     const matches = [
-      ...scenarios(policy, 'train', checked.trainSeeds, checked.seed, checked.inputDelays, ensemble),
-      ...scenarios(policy, 'held-out', checked.heldOutSeeds, checked.seed, checked.inputDelays, ensemble),
+      ...scenarios(policy, 'train', checked.trainSeeds, checked.seed, checked.delayScenarios, ensemble),
+      ...scenarios(policy, 'held-out', checked.heldOutSeeds, checked.seed, checked.delayScenarios, ensemble),
     ];
     return {
       policyId: policy.id, policySourceHash: policy.sourceHash, config: policy.config, configHash: policy.configHash,
       train: aggregate(matches.filter((m) => m.split === 'train')),
       heldOut: aggregate(matches.filter((m) => m.split === 'held-out')),
-      byDelay: checked.inputDelays.map((inputDelay) => ({
-        inputDelay,
-        train: aggregate(matches.filter((m) => m.split === 'train' && m.inputDelay === inputDelay)),
-        heldOut: aggregate(matches.filter((m) => m.split === 'held-out' && m.inputDelay === inputDelay)),
+      byScenario: checked.delayScenarios.map((scenario) => ({
+        scenario: { ...scenario },
+        train: aggregate(matches.filter((m) => m.split === 'train' && scenarioKey(m.delayScenario) === scenarioKey(scenario))),
+        heldOut: aggregate(matches.filter((m) => m.split === 'held-out' && scenarioKey(m.delayScenario) === scenarioKey(scenario))),
       })),
       matches,
     };
@@ -711,15 +729,15 @@ export async function runPolicyLab(options: PolicyLabOptions = {}): Promise<Poli
     },
     run: {
       seed: checked.seed, trainSeeds: [...checked.trainSeeds], heldOutSeeds: [...checked.heldOutSeeds],
-      inputDelays: [...checked.inputDelays], opponents: [...DEFAULT_OPPONENTS], sideAssignments: ['a', 'b'],
+      delayScenarios: checked.delayScenarios.map((scenario) => ({ ...scenario })), opponents: [...DEFAULT_OPPONENTS], sideAssignments: ['a', 'b'],
       candidateCount: candidateRows.length,
     },
     opponentEnsemble,
     search: {
       selectedPolicyId: selected.policyId, selectedConfig: selected.config, selectedConfigHash: selected.configHash,
       scoring: {
-        ordering: ['worst-delay cleanKoWins descending', 'total cleanKoWins descending', 'total timeoutPenalty ascending', 'worst-delay KO-terminal round margin descending', 'total KO-terminal round margin descending', 'configHash ascending'],
-        note: 'One config is frozen across all delays. Timeout wins receive zero clean-KO or round-margin credit and one penalty.',
+        ordering: ['worst-scenario cleanKoWins descending', 'total cleanKoWins descending', 'total timeoutPenalty ascending', 'worst-scenario KO-terminal round margin descending', 'total KO-terminal round margin descending', 'configHash ascending'],
+        note: 'One config is frozen across all asymmetric target/opponent delay scenarios. Timeout wins receive zero clean-KO or round-margin credit and one penalty.',
       },
       candidates: candidateRows,
       ...(checked.includeSearchMatches ? { matches: searchMatches } : {}),
@@ -741,6 +759,14 @@ function parseSeedList(value: string | undefined): number[] | undefined {
   return value?.split(',').filter(Boolean).map(Number);
 }
 
+function parseDelayScenarios(value: string | undefined): DelayScenario[] | undefined {
+  return value?.split(',').filter(Boolean).map((entry) => {
+    const parts = entry.split(':');
+    if (parts.length !== 2 || parts.some((part) => part === '')) throw new Error(`invalid delay scenario: ${entry}`);
+    return { targetDelay: Number(parts[0]), opponentDelay: Number(parts[1]) };
+  });
+}
+
 function parseArgs(argv: string[]): PolicyLabOptions & { pretty: boolean; help: boolean } {
   const values: Record<string, string> = {};
   let pretty = false, help = false, includeSearchMatches = false;
@@ -757,7 +783,7 @@ function parseArgs(argv: string[]): PolicyLabOptions & { pretty: boolean; help: 
   return {
     seed: values.seed ? Number(values.seed) : undefined,
     trainSeeds: parseSeedList(values['train-seeds']), heldOutSeeds: parseSeedList(values['held-out-seeds']),
-    inputDelays: parseSeedList(values['input-delays']),
+    delayScenarios: parseDelayScenarios(values['delay-scenarios']),
     candidateLimit: values.candidates ? Number(values.candidates) : undefined,
     includeSearchMatches, pretty, help,
   };
@@ -767,7 +793,7 @@ const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).hr
 if (import.meta.url === invokedPath) {
   const parsed = parseArgs(process.argv.slice(2));
   if (parsed.help) {
-    console.log(`Usage: pnpm policy:xenon [options]\n\nOptions:\n  --seed N                    run provenance seed\n  --train-seeds A,B,C         deterministic search/eval seeds\n  --held-out-seeds A,B,C      disjoint evaluation-only seeds\n  --input-delays A,B,C        unique delays in frames, each 0-30 (default 0,2,5)\n  --candidates N              bounded grid candidates (1-324)\n  --include-search-matches    include every search match in JSON\n  --pretty                    pretty-print JSON\n  --help                      show this help`);
+    console.log(`Usage: pnpm policy:xenon [options]\n\nOptions:\n  --seed N                    run provenance seed\n  --train-seeds A,B,C         deterministic search/eval seeds\n  --held-out-seeds A,B,C      disjoint evaluation-only seeds\n  --delay-scenarios T:O,...   unique target:opponent delays, each 0-30\n  --candidates N              bounded grid candidates (1-324)\n  --include-search-matches    include every search match in JSON\n  --pretty                    pretty-print JSON\n  --help                      show this help`);
   } else {
     const result = await runPolicyLab(parsed);
     console.log(JSON.stringify(result, null, parsed.pretty ? 2 : 0));

--- a/src/tools/xenon-policy-lab.ts
+++ b/src/tools/xenon-policy-lab.ts
@@ -152,17 +152,21 @@ export interface Aggregate {
 }
 
 export interface CandidateScore {
+  played: number;
   primaryCleanKoWins: number;
   timeoutPenalty: number;
   koRoundMargin: number;
 }
 
 export interface RobustCandidateScore {
+  worstCellCleanKoWins: number;
   worstScenarioCleanKoWins: number;
   totalCleanKoWins: number;
   totalTimeoutPenalty: number;
+  worstCellKoRoundMargin: number;
   worstScenarioKoRoundMargin: number;
   totalKoRoundMargin: number;
+  byCell: Array<{ scenario: DelayScenario; opponent: OpponentName; evidence: CandidateScore }>;
   byScenario: Array<{ scenario: DelayScenario; evidence: CandidateScore }>;
 }
 
@@ -617,6 +621,7 @@ function scenarios(
 export function score(matches: readonly MatchResult[]): CandidateScore {
   const koMatches = matches.filter((match) => match.terminal === 'ko');
   return {
+    played: matches.length,
     // Challenge objective: only executor wins ending in KO are primary evidence.
     primaryCleanKoWins: koMatches.filter((match) => match.outcome === 'win').length,
     // Every timeout is a penalty, including a timeout win. It contributes no
@@ -628,25 +633,36 @@ export function score(matches: readonly MatchResult[]): CandidateScore {
 
 const scenarioKey = (scenario: DelayScenario): string => `${scenario.targetDelay}:${scenario.opponentDelay}`;
 
-function robustScore(matches: readonly MatchResult[], delayScenarios: readonly DelayScenario[]): RobustCandidateScore {
+export function robustScore(matches: readonly MatchResult[], delayScenarios: readonly DelayScenario[]): RobustCandidateScore {
   const byScenario = delayScenarios.map((scenario) => ({
     scenario: { ...scenario },
     evidence: score(matches.filter((match) => scenarioKey(match.delayScenario) === scenarioKey(scenario))),
   }));
+  const byCell = delayScenarios.flatMap((scenario) => DEFAULT_OPPONENTS.map((opponent) => ({
+    scenario: { ...scenario },
+    opponent,
+    evidence: score(matches.filter((match) =>
+      scenarioKey(match.delayScenario) === scenarioKey(scenario) && match.opponent === opponent)),
+  })));
   return {
+    worstCellCleanKoWins: Math.min(...byCell.map((row) => row.evidence.primaryCleanKoWins)),
     worstScenarioCleanKoWins: Math.min(...byScenario.map((row) => row.evidence.primaryCleanKoWins)),
     totalCleanKoWins: byScenario.reduce((sum, row) => sum + row.evidence.primaryCleanKoWins, 0),
     totalTimeoutPenalty: byScenario.reduce((sum, row) => sum + row.evidence.timeoutPenalty, 0),
+    worstCellKoRoundMargin: Math.min(...byCell.map((row) => row.evidence.koRoundMargin)),
     worstScenarioKoRoundMargin: Math.min(...byScenario.map((row) => row.evidence.koRoundMargin)),
     totalKoRoundMargin: byScenario.reduce((sum, row) => sum + row.evidence.koRoundMargin, 0),
+    byCell,
     byScenario,
   };
 }
 
-function compareRobustScore(a: RobustCandidateScore, b: RobustCandidateScore): number {
-  return b.worstScenarioCleanKoWins - a.worstScenarioCleanKoWins
+export function compareRobustScore(a: RobustCandidateScore, b: RobustCandidateScore): number {
+  return b.worstCellCleanKoWins - a.worstCellCleanKoWins
+    || b.worstScenarioCleanKoWins - a.worstScenarioCleanKoWins
     || b.totalCleanKoWins - a.totalCleanKoWins
     || a.totalTimeoutPenalty - b.totalTimeoutPenalty
+    || b.worstCellKoRoundMargin - a.worstCellKoRoundMargin
     || b.worstScenarioKoRoundMargin - a.worstScenarioKoRoundMargin
     || b.totalKoRoundMargin - a.totalKoRoundMargin;
 }
@@ -736,8 +752,8 @@ export async function runPolicyLab(options: PolicyLabOptions = {}): Promise<Poli
     search: {
       selectedPolicyId: selected.policyId, selectedConfig: selected.config, selectedConfigHash: selected.configHash,
       scoring: {
-        ordering: ['worst-scenario cleanKoWins descending', 'total cleanKoWins descending', 'total timeoutPenalty ascending', 'worst-scenario KO-terminal round margin descending', 'total KO-terminal round margin descending', 'configHash ascending'],
-        note: 'One config is frozen across all asymmetric target/opponent delay scenarios. Timeout wins receive zero clean-KO or round-margin credit and one penalty.',
+        ordering: ['worst (delay scenario, opponent) cleanKoWins descending', 'worst-scenario cleanKoWins descending', 'total cleanKoWins descending', 'total timeoutPenalty ascending', 'worst (delay scenario, opponent) KO-terminal round margin descending', 'worst-scenario KO-terminal round margin descending', 'total KO-terminal round margin descending', 'configHash ascending'],
+        note: 'One config is frozen across all asymmetric target/opponent delay scenarios. Every fighter-delay cell has equal search exposure (reported as played) and is protected by the primary minimax floor. Timeout wins receive zero clean-KO or round-margin credit and one penalty.',
       },
       candidates: candidateRows,
       ...(checked.includeSearchMatches ? { matches: searchMatches } : {}),
@@ -768,6 +784,7 @@ function parseDelayScenarios(value: string | undefined): DelayScenario[] | undef
 }
 
 function parseArgs(argv: string[]): PolicyLabOptions & { pretty: boolean; help: boolean } {
+  const valueOptions = new Set(['seed', 'train-seeds', 'held-out-seeds', 'delay-scenarios', 'candidates']);
   const values: Record<string, string> = {};
   let pretty = false, help = false, includeSearchMatches = false;
   for (let i = 0; i < argv.length; i++) {
@@ -776,9 +793,12 @@ function parseArgs(argv: string[]): PolicyLabOptions & { pretty: boolean; help: 
     if (arg === '--include-search-matches') { includeSearchMatches = true; continue; }
     if (arg === '--help' || arg === '-h') { help = true; continue; }
     if (!arg.startsWith('--')) throw new Error(`unexpected argument: ${arg}`);
+    if (arg === '--input-delays') throw new Error('--input-delays was removed; use --delay-scenarios T:O,...');
+    const name = arg.slice(2);
+    if (!valueOptions.has(name)) throw new Error(`unknown option: ${arg}`);
     const value = argv[++i];
     if (!value || value.startsWith('--')) throw new Error(`${arg} requires a value`);
-    values[arg.slice(2)] = value;
+    values[name] = value;
   }
   return {
     seed: values.seed ? Number(values.seed) : undefined,

--- a/src/tools/xenon-policy-lab.ts
+++ b/src/tools/xenon-policy-lab.ts
@@ -24,6 +24,7 @@ const MECHANICS_FILES = ['game/engine.ts', 'game/moves.ts', 'game/types.ts'] as 
 const POLICY_SOURCE_VERSION = 'xenon-policy-lab-policies/v1';
 const DEFAULT_TRAIN_SEEDS = [101, 211, 307];
 const DEFAULT_HELD_OUT_SEEDS = [401, 503, 607];
+const DEFAULT_INPUT_DELAYS = [0, 2, 5];
 const DEFAULT_OPPONENTS = ['OMEGA', 'MNEME', 'AJAX', 'FABLE'] as const;
 // Three full 60-second rounds plus countdown/inter-round ceremony fit below this
 // cap. Reaching it is an error, never a draw silently folded into evaluation.
@@ -149,9 +150,18 @@ export interface CandidateScore {
   koRoundMargin: number;
 }
 
+export interface RobustCandidateScore {
+  worstDelayCleanKoWins: number;
+  totalCleanKoWins: number;
+  totalTimeoutPenalty: number;
+  worstDelayKoRoundMargin: number;
+  totalKoRoundMargin: number;
+  byDelay: Array<{ inputDelay: number; evidence: CandidateScore }>;
+}
+
 export interface CandidateSummary extends Aggregate {
   rank?: number;
-  score: CandidateScore;
+  score: RobustCandidateScore;
   policyId: string;
   config: XenonConfig;
   configHash: string;
@@ -164,6 +174,7 @@ export interface EvaluationBlock {
   configHash: string;
   train: Aggregate;
   heldOut: Aggregate;
+  byDelay: Array<{ inputDelay: number; train: Aggregate; heldOut: Aggregate }>;
   matches: MatchResult[];
 }
 
@@ -171,7 +182,7 @@ export interface PolicyLabOptions {
   seed?: number;
   trainSeeds?: number[];
   heldOutSeeds?: number[];
-  inputDelay?: number;
+  inputDelays?: number[];
   candidateLimit?: number;
   includeSearchMatches?: boolean;
 }
@@ -186,13 +197,14 @@ export interface PolicyLabResult {
     mechanicsFiles: string[];
     mechanicsValidated: true;
     validationScope: string;
+    deploymentScope: string;
     networkAccess: false;
   };
   run: {
     seed: number;
     trainSeeds: number[];
     heldOutSeeds: number[];
-    inputDelay: number;
+    inputDelays: number[];
     opponents: OpponentName[];
     sideAssignments: Side[];
     candidateCount: number;
@@ -576,11 +588,11 @@ function scenarios(
   split: Split,
   seeds: number[],
   runSeed: number,
-  inputDelay: number,
+  inputDelays: number[],
   ensemble: Map<string, PolicyDefinition>,
 ): MatchResult[] {
   const results: MatchResult[] = [];
-  for (const opponentName of DEFAULT_OPPONENTS) {
+  for (const inputDelay of inputDelays) for (const opponentName of DEFAULT_OPPONENTS) {
     const opponent = ensemble.get(`${split}:${opponentName}`)!;
     for (const seed of seeds) for (const side of ['a', 'b'] as const)
       results.push(playMatch(target, opponent, split, side, runSeed, seed, inputDelay));
@@ -600,25 +612,44 @@ export function score(matches: readonly MatchResult[]): CandidateScore {
   };
 }
 
-function compareScore(a: CandidateScore, b: CandidateScore): number {
-  return b.primaryCleanKoWins - a.primaryCleanKoWins
-    || a.timeoutPenalty - b.timeoutPenalty
-    || b.koRoundMargin - a.koRoundMargin;
+function robustScore(matches: readonly MatchResult[], inputDelays: readonly number[]): RobustCandidateScore {
+  const byDelay = inputDelays.map((inputDelay) => ({
+    inputDelay,
+    evidence: score(matches.filter((match) => match.inputDelay === inputDelay)),
+  }));
+  return {
+    worstDelayCleanKoWins: Math.min(...byDelay.map((row) => row.evidence.primaryCleanKoWins)),
+    totalCleanKoWins: byDelay.reduce((sum, row) => sum + row.evidence.primaryCleanKoWins, 0),
+    totalTimeoutPenalty: byDelay.reduce((sum, row) => sum + row.evidence.timeoutPenalty, 0),
+    worstDelayKoRoundMargin: Math.min(...byDelay.map((row) => row.evidence.koRoundMargin)),
+    totalKoRoundMargin: byDelay.reduce((sum, row) => sum + row.evidence.koRoundMargin, 0),
+    byDelay,
+  };
+}
+
+function compareRobustScore(a: RobustCandidateScore, b: RobustCandidateScore): number {
+  return b.worstDelayCleanKoWins - a.worstDelayCleanKoWins
+    || b.totalCleanKoWins - a.totalCleanKoWins
+    || a.totalTimeoutPenalty - b.totalTimeoutPenalty
+    || b.worstDelayKoRoundMargin - a.worstDelayKoRoundMargin
+    || b.totalKoRoundMargin - a.totalKoRoundMargin;
 }
 
 function validateOptions(options: PolicyLabOptions): Required<PolicyLabOptions> {
   const seed = options.seed ?? 1;
   const trainSeeds = options.trainSeeds ?? DEFAULT_TRAIN_SEEDS;
   const heldOutSeeds = options.heldOutSeeds ?? DEFAULT_HELD_OUT_SEEDS;
-  const inputDelay = options.inputDelay ?? 0;
+  const inputDelays = options.inputDelays ?? DEFAULT_INPUT_DELAYS;
   const candidateLimit = options.candidateLimit ?? 48;
   if (!Number.isInteger(seed)) throw new Error('seed must be an integer');
   if (!trainSeeds.length || !heldOutSeeds.length || [...trainSeeds, ...heldOutSeeds].some((s) => !Number.isInteger(s)))
     throw new Error('train and held-out seeds must be non-empty integer lists');
   if (trainSeeds.some((s) => heldOutSeeds.includes(s))) throw new Error('train and held-out seeds must be disjoint');
-  if (!Number.isInteger(inputDelay) || inputDelay < 0 || inputDelay > 30) throw new Error('inputDelay must be an integer from 0 to 30');
+  if (!inputDelays.length || inputDelays.some((delay) => !Number.isInteger(delay) || delay < 0 || delay > 30))
+    throw new Error('inputDelays must be a non-empty list of integers from 0 to 30');
+  if (new Set(inputDelays).size !== inputDelays.length) throw new Error('inputDelays must be unique');
   if (!Number.isInteger(candidateLimit) || candidateLimit < 1 || candidateLimit > 324) throw new Error('candidateLimit must be an integer from 1 to 324');
-  return { seed, trainSeeds, heldOutSeeds, inputDelay, candidateLimit, includeSearchMatches: options.includeSearchMatches ?? false };
+  return { seed, trainSeeds, heldOutSeeds, inputDelays: [...inputDelays], candidateLimit, includeSearchMatches: options.includeSearchMatches ?? false };
 }
 
 export async function runPolicyLab(options: PolicyLabOptions = {}): Promise<PolicyLabResult> {
@@ -633,25 +664,30 @@ export async function runPolicyLab(options: PolicyLabOptions = {}): Promise<Poli
   const searchMatches: MatchResult[] = [];
   for (const [index, config] of candidateConfigs(checked.candidateLimit).entries()) {
     const target = xenonPolicy(`xenon-search-${index.toString().padStart(3, '0')}`, 'searched-grid-v1', config);
-    const matches = scenarios(target, 'train', checked.trainSeeds, checked.seed, checked.inputDelay, ensemble);
+    const matches = scenarios(target, 'train', checked.trainSeeds, checked.seed, checked.inputDelays, ensemble);
     const totals = aggregate(matches);
-    candidateRows.push({ ...totals, score: score(matches), policyId: target.id, config, configHash: target.configHash });
+    candidateRows.push({ ...totals, score: robustScore(matches, checked.inputDelays), policyId: target.id, config, configHash: target.configHash });
     if (checked.includeSearchMatches) searchMatches.push(...matches);
   }
-  candidateRows.sort((a, b) => compareScore(a.score, b.score) || a.configHash.localeCompare(b.configHash));
+  candidateRows.sort((a, b) => compareRobustScore(a.score, b.score) || a.configHash.localeCompare(b.configHash));
   candidateRows.forEach((row, index) => { row.rank = index + 1; });
   const selected = candidateRows[0]!;
   const selectedPolicy = xenonPolicy(selected.policyId, 'searched-grid-v1', selected.config);
 
   const evaluate = (policy: PolicyDefinition): EvaluationBlock => {
     const matches = [
-      ...scenarios(policy, 'train', checked.trainSeeds, checked.seed, checked.inputDelay, ensemble),
-      ...scenarios(policy, 'held-out', checked.heldOutSeeds, checked.seed, checked.inputDelay, ensemble),
+      ...scenarios(policy, 'train', checked.trainSeeds, checked.seed, checked.inputDelays, ensemble),
+      ...scenarios(policy, 'held-out', checked.heldOutSeeds, checked.seed, checked.inputDelays, ensemble),
     ];
     return {
       policyId: policy.id, policySourceHash: policy.sourceHash, config: policy.config, configHash: policy.configHash,
       train: aggregate(matches.filter((m) => m.split === 'train')),
       heldOut: aggregate(matches.filter((m) => m.split === 'held-out')),
+      byDelay: checked.inputDelays.map((inputDelay) => ({
+        inputDelay,
+        train: aggregate(matches.filter((m) => m.split === 'train' && m.inputDelay === inputDelay)),
+        heldOut: aggregate(matches.filter((m) => m.split === 'held-out' && m.inputDelay === inputDelay)),
+      })),
       matches,
     };
   };
@@ -670,19 +706,20 @@ export async function runPolicyLab(options: PolicyLabOptions = {}): Promise<Poli
       mechanicsHash, expectedMechanicsHash: EXPECTED_MECHANICS_HASH,
       mechanicsFiles: MECHANICS_FILES.map((file) => `src/${file}`), mechanicsValidated: true,
       validationScope: 'Exact mechanics snapshot only; stage art/selection and sprites are excluded because the lab pins the cosmetic stage and does not render.',
+      deploymentScope: 'Pinned to deployed live snapshot 991acfe; undeployed main 9fd5609 (UNCLOSE) is explicitly excluded.',
       networkAccess: false,
     },
     run: {
       seed: checked.seed, trainSeeds: [...checked.trainSeeds], heldOutSeeds: [...checked.heldOutSeeds],
-      inputDelay: checked.inputDelay, opponents: [...DEFAULT_OPPONENTS], sideAssignments: ['a', 'b'],
+      inputDelays: [...checked.inputDelays], opponents: [...DEFAULT_OPPONENTS], sideAssignments: ['a', 'b'],
       candidateCount: candidateRows.length,
     },
     opponentEnsemble,
     search: {
       selectedPolicyId: selected.policyId, selectedConfig: selected.config, selectedConfigHash: selected.configHash,
       scoring: {
-        ordering: ['cleanKoWins descending', 'timeoutPenalty ascending', 'KO-terminal round margin descending', 'configHash ascending'],
-        note: 'Timeout wins remain descriptive wins but receive zero primary or round-margin credit and one timeout penalty.',
+        ordering: ['worst-delay cleanKoWins descending', 'total cleanKoWins descending', 'total timeoutPenalty ascending', 'worst-delay KO-terminal round margin descending', 'total KO-terminal round margin descending', 'configHash ascending'],
+        note: 'One config is frozen across all delays. Timeout wins receive zero clean-KO or round-margin credit and one penalty.',
       },
       candidates: candidateRows,
       ...(checked.includeSearchMatches ? { matches: searchMatches } : {}),
@@ -720,7 +757,7 @@ function parseArgs(argv: string[]): PolicyLabOptions & { pretty: boolean; help: 
   return {
     seed: values.seed ? Number(values.seed) : undefined,
     trainSeeds: parseSeedList(values['train-seeds']), heldOutSeeds: parseSeedList(values['held-out-seeds']),
-    inputDelay: values['input-delay'] ? Number(values['input-delay']) : undefined,
+    inputDelays: parseSeedList(values['input-delays']),
     candidateLimit: values.candidates ? Number(values.candidates) : undefined,
     includeSearchMatches, pretty, help,
   };
@@ -730,7 +767,7 @@ const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).hr
 if (import.meta.url === invokedPath) {
   const parsed = parseArgs(process.argv.slice(2));
   if (parsed.help) {
-    console.log(`Usage: pnpm policy:xenon [options]\n\nOptions:\n  --seed N                    run provenance seed\n  --train-seeds A,B,C         deterministic search/eval seeds\n  --held-out-seeds A,B,C      disjoint evaluation-only seeds\n  --input-delay N             action delay in frames (0-30)\n  --candidates N              bounded grid candidates (1-324)\n  --include-search-matches    include every search match in JSON\n  --pretty                    pretty-print JSON\n  --help                      show this help`);
+    console.log(`Usage: pnpm policy:xenon [options]\n\nOptions:\n  --seed N                    run provenance seed\n  --train-seeds A,B,C         deterministic search/eval seeds\n  --held-out-seeds A,B,C      disjoint evaluation-only seeds\n  --input-delays A,B,C        unique delays in frames, each 0-30 (default 0,2,5)\n  --candidates N              bounded grid candidates (1-324)\n  --include-search-matches    include every search match in JSON\n  --pretty                    pretty-print JSON\n  --help                      show this help`);
   } else {
     const result = await runPolicyLab(parsed);
     console.log(JSON.stringify(result, null, parsed.pretty ? 2 : 0));

--- a/src/xenon-policy-lab-test.ts
+++ b/src/xenon-policy-lab-test.ts
@@ -10,7 +10,7 @@ const options = {
   seed: 17,
   trainSeeds: [101],
   heldOutSeeds: [401],
-  inputDelay: 2,
+  inputDelays: [0, 2],
   candidateLimit: 2,
   includeSearchMatches: true,
 };
@@ -22,6 +22,7 @@ check('provenance pins exact engine commit and offline execution',
   first.schema === LAB_SCHEMA && first.engine.expectedBaseCommit === ENGINE_COMMIT
     && first.engine.mechanicsHash === EXPECTED_MECHANICS_HASH && first.engine.mechanicsValidated
     && first.engine.mechanicsFiles.join(',') === 'src/game/engine.ts,src/game/moves.ts,src/game/types.ts'
+    && first.engine.deploymentScope.includes('991acfe') && first.engine.deploymentScope.includes('9fd5609')
     && !first.engine.networkAccess);
 let mechanicsMismatchRejected = false, versionMismatchRejected = false;
 try { validateMechanicsSnapshot('0'.repeat(64)); } catch { mechanicsMismatchRejected = true; }
@@ -37,14 +38,15 @@ check('search is bounded and hashes every configuration',
 const searchedMatches = first.search.matches ?? [];
 const seedTuple = (m: typeof searchedMatches[number]): string =>
   `${m.streamRootSeed}|${m.matchSeed}|${m.targetPolicySeed}|${m.opponentPolicySeed}`;
-check('candidate configs and paired seats share common random-number streams',
-  searchedMatches.length === 16 && ['OMEGA', 'MNEME', 'AJAX', 'FABLE'].every((opponent) => {
+check('candidate configs, delays, and paired seats share common random-number streams',
+  searchedMatches.length === 32 && ['OMEGA', 'MNEME', 'AJAX', 'FABLE'].every((opponent) => {
     const scenario = searchedMatches.filter((m) => m.opponent === opponent && m.scenarioSeed === 101);
-    return scenario.length === 4
+    return scenario.length === 8
       && new Set(scenario.map((m) => m.targetConfigHash)).size === 2
       && new Set(scenario.map(seedTuple)).size === 1
       && new Set(scenario.map((m) => m.executorSide)).size === 2
-      && new Set(scenario.map((m) => m.id)).size === 4;
+      && new Set(scenario.map((m) => m.inputDelay)).size === 2
+      && new Set(scenario.map((m) => m.id)).size === 8;
   }));
 
 const blocks = [first.evaluation.searched, ...first.evaluation.frozenBaselines];
@@ -52,17 +54,19 @@ check('searched policy is compared with two frozen baselines', first.evaluation.
 check('every block evaluates disjoint train/held-out seeds on both sides', blocks.every((block) => {
   const train = block.matches.filter((m) => m.split === 'train');
   const held = block.matches.filter((m) => m.split === 'held-out');
-  return train.length === 8 && held.length === 8
+  return train.length === 16 && held.length === 16
     && new Set(train.map((m) => m.executorSide)).size === 2
     && new Set(held.map((m) => m.executorSide)).size === 2
-    && train.every((m) => m.inputDelay === 2 && m.scenarioSeed === 101 && m.matchSeed !== m.scenarioSeed)
-    && held.every((m) => m.inputDelay === 2 && m.scenarioSeed === 401 && m.matchSeed !== m.scenarioSeed)
+    && new Set(train.map((m) => m.inputDelay)).size === 2
+    && new Set(held.map((m) => m.inputDelay)).size === 2
+    && train.every((m) => m.scenarioSeed === 101 && m.matchSeed !== m.scenarioSeed)
+    && held.every((m) => m.scenarioSeed === 401 && m.matchSeed !== m.scenarioSeed)
     && block.matches.every((m) => m.targetPolicySeed !== m.opponentPolicySeed);
 }));
 check('paired seats and frozen/selected policies preserve the same scenario streams',
   ['train', 'held-out'].every((split) => ['OMEGA', 'MNEME', 'AJAX', 'FABLE'].every((opponent) => {
     const scenario = blocks.flatMap((block) => block.matches).filter((m) => m.split === split && m.opponent === opponent);
-    return scenario.length === 6 && new Set(scenario.map(seedTuple)).size === 1;
+    return scenario.length === 12 && new Set(scenario.map(seedTuple)).size === 1;
   })));
 check('train/held-out and target/opponent streams remain disjoint',
   blocks.every((block) => {
@@ -92,7 +96,11 @@ check('aggregate clean-KO and timeout fields are executor-relative and unambiguo
       && aggregate.koRoundsWon === matches.filter((m) => m.terminal === 'ko').reduce((sum, m) => sum + m.rounds.executor, 0)
       && aggregate.koRoundsLost === matches.filter((m) => m.terminal === 'ko').reduce((sum, m) => sum + m.rounds.opponent, 0);
   })));
-const timeoutFixture = await runPolicyLab({ ...options, inputDelay: 0, candidateLimit: 1, includeSearchMatches: false });
+check('one selected config hash is frozen across every evaluation delay',
+  first.evaluation.searched.byDelay.length === 2
+    && new Set(first.evaluation.searched.matches.map((m) => m.targetConfigHash)).size === 1
+    && first.evaluation.searched.matches.every((m) => m.targetConfigHash === first.search.selectedConfigHash));
+const timeoutFixture = await runPolicyLab({ ...options, inputDelays: [0], candidateLimit: 1, includeSearchMatches: false });
 const timeoutWin = [timeoutFixture.evaluation.searched, ...timeoutFixture.evaluation.frozenBaselines]
   .flatMap((block) => block.matches).find((m) => m.outcome === 'win' && m.terminal === 'time');
 const timeoutOnlyScore = timeoutWin ? score([timeoutWin]) : null;
@@ -101,15 +109,20 @@ check('a timeout win has zero primary and round-margin credit plus one penalty',
     && timeoutOnlyScore?.primaryCleanKoWins === 0
     && timeoutOnlyScore.koRoundMargin === 0
     && timeoutOnlyScore.timeoutPenalty === 1);
-check('reported candidate scoring declares clean-KO-first timeout-penalized ordering',
-  first.search.scoring.ordering.join('|') === 'cleanKoWins descending|timeoutPenalty ascending|KO-terminal round margin descending|configHash ascending'
-    && first.search.candidates.every((candidate) => candidate.score.primaryCleanKoWins === candidate.cleanKoWins
-      && candidate.score.timeoutPenalty === candidate.timeoutWins + candidate.timeoutLosses
-      && candidate.score.koRoundMargin === candidate.koRoundsWon - candidate.koRoundsLost));
+check('reported minimax scoring is delay-robust and internally consistent',
+  first.search.scoring.ordering[0] === 'worst-delay cleanKoWins descending'
+    && first.search.candidates.every((candidate) => candidate.score.byDelay.length === 2
+      && candidate.score.worstDelayCleanKoWins === Math.min(...candidate.score.byDelay.map((row) => row.evidence.primaryCleanKoWins))
+      && candidate.score.totalCleanKoWins === candidate.cleanKoWins
+      && candidate.score.totalTimeoutPenalty === candidate.timeoutWins + candidate.timeoutLosses
+      && candidate.score.totalKoRoundMargin === candidate.koRoundsWon - candidate.koRoundsLost));
 
 let overlapRejected = false;
 try { await runPolicyLab({ trainSeeds: [1], heldOutSeeds: [1], candidateLimit: 1 }); } catch { overlapRejected = true; }
 check('overlapping train/held-out seeds fail fast', overlapRejected);
+let duplicateDelaysRejected = false;
+try { await runPolicyLab({ trainSeeds: [1], heldOutSeeds: [2], inputDelays: [0, 0], candidateLimit: 1 }); } catch { duplicateDelaysRejected = true; }
+check('duplicate delay conditions fail fast', duplicateDelaysRejected);
 
 console.log(pass ? '\nXENON POLICY LAB TEST: PASS' : '\nXENON POLICY LAB TEST: FAIL');
 process.exit(pass ? 0 : 1);

--- a/src/xenon-policy-lab-test.ts
+++ b/src/xenon-policy-lab-test.ts
@@ -1,4 +1,4 @@
-import { runPolicyLab, score, validateMechanicsSnapshot, ENGINE_COMMIT, EXPECTED_MECHANICS_HASH, LAB_SCHEMA } from './tools/xenon-policy-lab.js';
+import { delaysBySeat, runPolicyLab, score, validateMechanicsSnapshot, ENGINE_COMMIT, EXPECTED_MECHANICS_HASH, LAB_SCHEMA } from './tools/xenon-policy-lab.js';
 
 let pass = true;
 const check = (name: string, ok: boolean, detail = ''): void => {
@@ -10,7 +10,7 @@ const options = {
   seed: 17,
   trainSeeds: [101],
   heldOutSeeds: [401],
-  inputDelays: [0, 2],
+  delayScenarios: [{ targetDelay: 0, opponentDelay: 2 }, { targetDelay: 2, opponentDelay: 0 }],
   candidateLimit: 2,
   includeSearchMatches: true,
 };
@@ -45,7 +45,7 @@ check('candidate configs, delays, and paired seats share common random-number st
       && new Set(scenario.map((m) => m.targetConfigHash)).size === 2
       && new Set(scenario.map(seedTuple)).size === 1
       && new Set(scenario.map((m) => m.executorSide)).size === 2
-      && new Set(scenario.map((m) => m.inputDelay)).size === 2
+      && new Set(scenario.map((m) => `${m.delayScenario.targetDelay}:${m.delayScenario.opponentDelay}`)).size === 2
       && new Set(scenario.map((m) => m.id)).size === 8;
   }));
 
@@ -57,8 +57,8 @@ check('every block evaluates disjoint train/held-out seeds on both sides', block
   return train.length === 16 && held.length === 16
     && new Set(train.map((m) => m.executorSide)).size === 2
     && new Set(held.map((m) => m.executorSide)).size === 2
-    && new Set(train.map((m) => m.inputDelay)).size === 2
-    && new Set(held.map((m) => m.inputDelay)).size === 2
+    && new Set(train.map((m) => `${m.delayScenario.targetDelay}:${m.delayScenario.opponentDelay}`)).size === 2
+    && new Set(held.map((m) => `${m.delayScenario.targetDelay}:${m.delayScenario.opponentDelay}`)).size === 2
     && train.every((m) => m.scenarioSeed === 101 && m.matchSeed !== m.scenarioSeed)
     && held.every((m) => m.scenarioSeed === 401 && m.matchSeed !== m.scenarioSeed)
     && block.matches.every((m) => m.targetPolicySeed !== m.opponentPolicySeed);
@@ -97,10 +97,18 @@ check('aggregate clean-KO and timeout fields are executor-relative and unambiguo
       && aggregate.koRoundsLost === matches.filter((m) => m.terminal === 'ko').reduce((sum, m) => sum + m.rounds.opponent, 0);
   })));
 check('one selected config hash is frozen across every evaluation delay',
-  first.evaluation.searched.byDelay.length === 2
+  first.evaluation.searched.byScenario.length === 2
     && new Set(first.evaluation.searched.matches.map((m) => m.targetConfigHash)).size === 1
     && first.evaluation.searched.matches.every((m) => m.targetConfigHash === first.search.selectedConfigHash));
-const timeoutFixture = await runPolicyLab({ ...options, inputDelays: [0], candidateLimit: 1, includeSearchMatches: false });
+check('asymmetric delay queues follow policy role across both seats',
+  delaysBySeat({ targetDelay: 5, opponentDelay: 2 }, 'a').a === 5
+    && delaysBySeat({ targetDelay: 5, opponentDelay: 2 }, 'a').b === 2
+    && delaysBySeat({ targetDelay: 5, opponentDelay: 2 }, 'b').a === 2
+    && delaysBySeat({ targetDelay: 5, opponentDelay: 2 }, 'b').b === 5
+    && first.evaluation.searched.matches.every((m) => m.executorSide === 'a'
+      ? m.seatDelays.a === m.delayScenario.targetDelay && m.seatDelays.b === m.delayScenario.opponentDelay
+      : m.seatDelays.b === m.delayScenario.targetDelay && m.seatDelays.a === m.delayScenario.opponentDelay));
+const timeoutFixture = await runPolicyLab({ ...options, delayScenarios: [{ targetDelay: 0, opponentDelay: 0 }], candidateLimit: 1, includeSearchMatches: false });
 const timeoutWin = [timeoutFixture.evaluation.searched, ...timeoutFixture.evaluation.frozenBaselines]
   .flatMap((block) => block.matches).find((m) => m.outcome === 'win' && m.terminal === 'time');
 const timeoutOnlyScore = timeoutWin ? score([timeoutWin]) : null;
@@ -110,9 +118,9 @@ check('a timeout win has zero primary and round-margin credit plus one penalty',
     && timeoutOnlyScore.koRoundMargin === 0
     && timeoutOnlyScore.timeoutPenalty === 1);
 check('reported minimax scoring is delay-robust and internally consistent',
-  first.search.scoring.ordering[0] === 'worst-delay cleanKoWins descending'
-    && first.search.candidates.every((candidate) => candidate.score.byDelay.length === 2
-      && candidate.score.worstDelayCleanKoWins === Math.min(...candidate.score.byDelay.map((row) => row.evidence.primaryCleanKoWins))
+  first.search.scoring.ordering[0] === 'worst-scenario cleanKoWins descending'
+    && first.search.candidates.every((candidate) => candidate.score.byScenario.length === 2
+      && candidate.score.worstScenarioCleanKoWins === Math.min(...candidate.score.byScenario.map((row) => row.evidence.primaryCleanKoWins))
       && candidate.score.totalCleanKoWins === candidate.cleanKoWins
       && candidate.score.totalTimeoutPenalty === candidate.timeoutWins + candidate.timeoutLosses
       && candidate.score.totalKoRoundMargin === candidate.koRoundsWon - candidate.koRoundsLost));
@@ -120,9 +128,9 @@ check('reported minimax scoring is delay-robust and internally consistent',
 let overlapRejected = false;
 try { await runPolicyLab({ trainSeeds: [1], heldOutSeeds: [1], candidateLimit: 1 }); } catch { overlapRejected = true; }
 check('overlapping train/held-out seeds fail fast', overlapRejected);
-let duplicateDelaysRejected = false;
-try { await runPolicyLab({ trainSeeds: [1], heldOutSeeds: [2], inputDelays: [0, 0], candidateLimit: 1 }); } catch { duplicateDelaysRejected = true; }
-check('duplicate delay conditions fail fast', duplicateDelaysRejected);
+let duplicateScenariosRejected = false;
+try { await runPolicyLab({ trainSeeds: [1], heldOutSeeds: [2], delayScenarios: [{ targetDelay: 0, opponentDelay: 2 }, { targetDelay: 0, opponentDelay: 2 }], candidateLimit: 1 }); } catch { duplicateScenariosRejected = true; }
+check('duplicate delay scenarios fail fast', duplicateScenariosRejected);
 
 console.log(pass ? '\nXENON POLICY LAB TEST: PASS' : '\nXENON POLICY LAB TEST: FAIL');
 process.exit(pass ? 0 : 1);

--- a/src/xenon-policy-lab-test.ts
+++ b/src/xenon-policy-lab-test.ts
@@ -1,4 +1,6 @@
-import { delaysBySeat, runPolicyLab, score, validateMechanicsSnapshot, ENGINE_COMMIT, EXPECTED_MECHANICS_HASH, LAB_SCHEMA } from './tools/xenon-policy-lab.js';
+import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { compareRobustScore, delaysBySeat, robustScore, runPolicyLab, score, validateMechanicsSnapshot, ENGINE_COMMIT, EXPECTED_MECHANICS_HASH, LAB_SCHEMA, type DelayScenario, type MatchResult } from './tools/xenon-policy-lab.js';
 
 let pass = true;
 const check = (name: string, ok: boolean, detail = ''): void => {
@@ -117,12 +119,37 @@ check('a timeout win has zero primary and round-margin credit plus one penalty',
     && timeoutOnlyScore?.primaryCleanKoWins === 0
     && timeoutOnlyScore.koRoundMargin === 0
     && timeoutOnlyScore.timeoutPenalty === 1);
+const rankingScenarios: DelayScenario[] = [
+  { targetDelay: 0, opponentDelay: 0 },
+  { targetDelay: 5, opponentDelay: 0 },
+];
+const rankingOpponents = ['OMEGA', 'MNEME', 'AJAX', 'FABLE'] as const;
+const syntheticRows = (balanced: boolean): MatchResult[] => rankingScenarios.flatMap((delayScenario, scenarioIndex) =>
+  rankingOpponents.flatMap((opponent, opponentIndex) => [0, 1].map((seatIndex) => {
+    const win = balanced ? seatIndex === 0 : !(scenarioIndex === 0 && opponentIndex === 0);
+    return {
+      delayScenario, opponent, outcome: win ? 'win' : 'loss', winner: win ? 'executor' : 'opponent',
+      terminal: 'ko', cleanKoWin: win, koTerminal: true,
+      rounds: win ? { executor: 2, opponent: 0 } : { executor: 0, opponent: 2 },
+    } as unknown as MatchResult;
+  })));
+const catastrophicScore = robustScore(syntheticRows(false), rankingScenarios);
+const balancedScore = robustScore(syntheticRows(true), rankingScenarios);
+check('cell minimax rejects aggregate strength that catastrophically fails one fighter-delay cell',
+  catastrophicScore.totalCleanKoWins > balancedScore.totalCleanKoWins
+    && catastrophicScore.worstCellCleanKoWins === 0
+    && balancedScore.worstCellCleanKoWins === 1
+    && compareRobustScore(balancedScore, catastrophicScore) < 0);
 check('reported minimax scoring is delay-robust and internally consistent',
-  first.search.scoring.ordering[0] === 'worst-scenario cleanKoWins descending'
+  first.search.scoring.ordering[0] === 'worst (delay scenario, opponent) cleanKoWins descending'
     && first.search.candidates.every((candidate) => candidate.score.byScenario.length === 2
+      && candidate.score.byCell.length === 8
+      && new Set(candidate.score.byCell.map((row) => row.evidence.played)).size === 1
+      && candidate.score.worstCellCleanKoWins === Math.min(...candidate.score.byCell.map((row) => row.evidence.primaryCleanKoWins))
       && candidate.score.worstScenarioCleanKoWins === Math.min(...candidate.score.byScenario.map((row) => row.evidence.primaryCleanKoWins))
       && candidate.score.totalCleanKoWins === candidate.cleanKoWins
       && candidate.score.totalTimeoutPenalty === candidate.timeoutWins + candidate.timeoutLosses
+      && candidate.score.worstCellKoRoundMargin === Math.min(...candidate.score.byCell.map((row) => row.evidence.koRoundMargin))
       && candidate.score.totalKoRoundMargin === candidate.koRoundsWon - candidate.koRoundsLost));
 
 let overlapRejected = false;
@@ -131,6 +158,25 @@ check('overlapping train/held-out seeds fail fast', overlapRejected);
 let duplicateScenariosRejected = false;
 try { await runPolicyLab({ trainSeeds: [1], heldOutSeeds: [2], delayScenarios: [{ targetDelay: 0, opponentDelay: 2 }, { targetDelay: 0, opponentDelay: 2 }], candidateLimit: 1 }); } catch { duplicateScenariosRejected = true; }
 check('duplicate delay scenarios fail fast', duplicateScenariosRejected);
+
+const cli = resolve('node_modules/.bin/tsx');
+const cliSource = resolve('src/tools/xenon-policy-lab.ts');
+const removedFlag = spawnSync(cli, [cliSource, '--input-delays', '9'], { encoding: 'utf8', timeout: 5_000 });
+const unknownFlag = spawnSync(cli, [cliSource, '--bogus', '9'], { encoding: 'utf8', timeout: 5_000 });
+check('removed input-delay CLI cannot silently launch the default run',
+  removedFlag.status !== 0 && removedFlag.stdout === ''
+    && removedFlag.stderr.includes('use --delay-scenarios T:O,...'));
+check('unknown CLI options fail closed before producing output',
+  unknownFlag.status !== 0 && unknownFlag.stdout === '' && unknownFlag.stderr.includes('unknown option: --bogus'));
+const supportedFlags = spawnSync(cli, [cliSource,
+  '--seed', '3', '--train-seeds', '11', '--held-out-seeds', '13',
+  '--delay-scenarios', '0:0', '--candidates', '1', '--include-search-matches', '--pretty',
+], { encoding: 'utf8', timeout: 15_000 });
+let supportedJson = false;
+try { supportedJson = JSON.parse(supportedFlags.stdout).schema === LAB_SCHEMA; } catch { /* asserted below */ }
+const helpFlag = spawnSync(cli, [cliSource, '--help'], { encoding: 'utf8', timeout: 5_000 });
+check('all documented CLI options are accepted deliberately',
+  supportedFlags.status === 0 && supportedJson && helpFlag.status === 0 && helpFlag.stdout.startsWith('Usage:'));
 
 console.log(pass ? '\nXENON POLICY LAB TEST: PASS' : '\nXENON POLICY LAB TEST: FAIL');
 process.exit(pass ? 0 : 1);


### PR DESCRIPTION
## Purpose

Preserves the sole uncommitted copy of a throwaway XENON latency counterfactual and ordered diagnostic trace before removing its broken 390 MB checkout. This is an archival/review PR, not a balance proposal or merge recommendation.

## Provenance

- Recovered from `/tmp/xenon-latency-trace.PKepCN` whose `.git` metadata had already been removed.
- Reproduced byte-for-byte: source blob `88f9063fcd4d75457142643baad748fadc4e78d5`.
- Based on historical experiment commit `30e17e5a22a84d6c868b5e0b9fc172fe95873c1b`.
- Adds opt-in trace records and an explicitly throwaway FABLE/MNEME latency counterfactual.

## Verification

- `git diff --check` passes.
- Focused historical `pnpm test:policy-lab`: 22/23 assertions pass. The timeout-win scoring assertion fails under this recovered experimental state; this is disclosed rather than repaired because changing the file would break exact preservation.

## Review gate

Do not merge as-is. Rebase/port selectively onto current mechanics, re-attest exact-engine provenance, and decide whether the counterfactual itself is still scientifically useful. No live controller, queue, match, or balance state was touched.