### PR TITLE
Restore TISSUE and Ultra technical dossiers

### DIFF
--- a/web/app/bots/list/page.tsx
+++ b/web/app/bots/list/page.tsx
@@ -6,22 +6,48 @@ import { winRate } from '@/lib/format';
 export const dynamic = 'force-dynamic';
 export const metadata = {
   title: 'Bot roster',
-  description: 'Ranked automated players competing in the SSH Fighter Open League.',
+  description: 'Technical bot dossiers and ranked automated players competing in the SSH Fighter Open League.',
 };
+
+const dossiers = [
+  {
+    name: 'TISSUE-0',
+    identity: 'ajax-tissue',
+    kind: 'Research organism',
+    runtime: 'Haskell · HaskTorch',
+    copy: 'A 5.54M-parameter genome grows a 12 × 12 morphogenetic control tissue, then adapts temporary immune clones and phase state during each match.',
+    href: '/bots/list/tissue',
+    accent: 'cyan',
+  },
+  {
+    name: 'Ultra',
+    identity: 'ajax-bot-ultra',
+    kind: 'Universal learned agent',
+    runtime: 'Native C · recurrent PPO',
+    copy: 'One recurrent policy rotates through all 17 fighters. Its native runtime consumes exact-engine self-play weights through a shared semantic control interface.',
+    href: '/bots/list/ultra',
+    accent: 'gold',
+  },
+];
 
 export default function BotListPage() {
   const bots = topPlayers(200, 'bots');
   const s = summary();
   const peak = bots[0]?.elo ?? 1200;
+  const online = onlineNow();
 
   return (
-    <div className="rs">
-      <SiteNav active="/bots" online={onlineNow()} />
-      <main className="rs-wrap">
-        <div className="rs-ph">
+    <div className="rs bots-list-page">
+      <SiteNav active="/bots" online={online} />
+      <main className="rs-wrap bots-list-wrap">
+        <header className="bots-list-hero">
+          <p>Technical dossiers · live ladder · external codebases</p>
           <h1>Bot roster</h1>
-          <p>Automated accounts competing in the Open League. Every bot uses its own SSH identity and external codebase.</p>
-        </div>
+          <div>
+            <p>Study two very different control systems, then compare every automated account on the live Open League ladder.</p>
+            <Link href="/bots">Build your own bot →</Link>
+          </div>
+        </header>
 
         <nav className="rs-divisions" aria-label="Bot pages">
           <Link className="rs-pill" href="/bots">Build a bot</Link>
@@ -29,14 +55,36 @@ export default function BotListPage() {
           <Link className="rs-pill" href="/leaderboard?division=open">Open League</Link>
         </nav>
 
-        <section className="rs-stats" style={{ marginTop: 18 }}>
+        <section className="bots-list-grid" aria-label="Technical bot dossiers">
+          {dossiers.map((bot, index) => (
+            <article className="bots-list-card" data-accent={bot.accent} key={bot.identity}>
+              <div className="bots-list-card__top"><i>{String(index + 1).padStart(2, '0')}</i><span>technical dossier</span></div>
+              <h2>{bot.name}</h2>
+              <p className="bots-list-card__identity">@{bot.identity}</p>
+              <dl>
+                <div><dt>Class</dt><dd>{bot.kind}</dd></div>
+                <div><dt>Runtime</dt><dd>{bot.runtime}</dd></div>
+              </dl>
+              <p className="bots-list-card__copy">{bot.copy}</p>
+              <Link href={bot.href}>Read technical dossier <span aria-hidden="true">→</span></Link>
+            </article>
+          ))}
+        </section>
+
+        <section className="bots-list-note">
+          <span>Repository boundary</span>
+          <p>The dossiers document publicly observable systems and their evidence. Their policies, training stacks and deployment services remain in independent repositories; SSH Fighter contains only the shared protocol, generic example and public presentation.</p>
+        </section>
+
+        <section className="rs-stats">
           <div className="rs-stat hl"><b>{s.bots}</b><span>Registered bots</span></div>
           <div className="rs-stat"><b>{bots.length}</b><span>Ranked bots</span></div>
           <div className="rs-stat"><b>{peak}</b><span>Top bot Elo</span></div>
-          <div className="rs-stat"><b>{onlineNow()}</b><span>Online now</span></div>
+          <div className="rs-stat"><b>{online}</b><span>Online now</span></div>
         </section>
 
         <section className="rs-section">
+          <div className="rs-section__head"><h2>Live bot ladder</h2><Link href="/leaderboard?division=open">Open League →</Link></div>
           <div style={{ overflowX: 'auto' }}>
             <table className="rs-table">
               <thead>

--- a/web/app/bots/list/tissue/page.tsx
+++ b/web/app/bots/list/tissue/page.tsx
@@ -1,0 +1,266 @@
+import Link from 'next/link';
+import { Footer, SiteNav } from '@/components/ui';
+
+export const metadata = {
+  title: 'TISSUE-0 bot',
+  description: 'A technical explanation of TISSUE-0, the morphogenetic immune control policy fighting live on SSH Fighter.',
+  alternates: { canonical: '/bots/list/tissue' },
+};
+
+const runtimeState = [
+  ['Fine tissue', '12 × 12 × 64', 'Fast electrical state shared by local cell updates'],
+  ['Morphogens', '12 × 12 × 8', 'Reaction–diffusion fields that influence cell roles'],
+  ['Phase memory', '12 × 12 × 2', 'Slow complex field with a differentiable defect map'],
+  ['Coarse organs', '3 × 3 × 96', 'Match-scale state with a 16-channel endocrine return path'],
+  ['Immune repertoire', '32 clones', '32-D receptors, 48-D adapter codes and concentrations'],
+  ['Motor vocabulary', '63 actions', '9 locomotion states × 7 combat commitments'],
+];
+
+const tickStages = [
+  ['01', 'Encode', 'Parse only actor-visible wire state: both fighters, acknowledgement, phase and up to eight nearest projectiles. Projectile features include relative velocity, eight-frame projection and estimated contact time.'],
+  ['02', 'Predict', 'Encode the observation and the residual against the tissue’s previous next-observation prediction. Predictable neutral frames create less internal disturbance than tactical surprise.'],
+  ['03', 'Recognise', 'Turn residual plus observation into a normalized antigen. Compare it with 32 learned receptors, subtract receptor similarity and open adaptation in proportion to a learned danger gate.'],
+  ['04', 'Compute', 'Run four recurrent tissue microsteps. Spatial, prediction, phase-memory and immune branches update the same 144 cells while coarse organs broadcast a narrow endocrine signal.'],
+  ['05', 'Vote', 'Every territory emits semantic action evidence. A differentiable quorum accumulates geographically distributed support and hysteresis discourages frame-to-frame action chatter.'],
+  ['06', 'Compile', 'Mask illegal actions, select one of 63 semantic commitments and deterministically compile it into facing-correct movement, buttons and character-specific special motions.'],
+];
+
+const evidence = [
+  ['Implemented', 'The full developmental, phase-field, clone, condensate, organ and quorum paths execute in the Haskell policy and can be intervened on independently.'],
+  ['Operational', 'The promoted checkpoint runs as ajax-tissue through the public SSH wire protocol. Production inference uses an asynchronous latest-observation worker.'],
+  ['Measured', 'The current r8 checkpoint passed its declared paired held-out, persistent temporal-lesion and 30 Hz CUDA gates on an RTX 3070 after a 64/64 round-boundary-balanced immune repair.'],
+  ['Not established', 'Static results do not yet prove opponent-specific within-match learning. Phase interventions are nearly null, and immune-removal divergence decreased rather than increased after the r8 repair.'],
+];
+
+const exampleBot = 'https://github.com/thomasdavis/sshfighter.com/blob/main/examples/bot.mjs';
+
+function TensorDiagram() {
+  return (
+    <div className="bots-diagram" aria-label="TISSUE-0 information flow">
+      <div className="bots-diagram__input"><span>WIRE STATE</span><b>prediction residual</b></div>
+      <div className="bots-diagram__arrow" aria-hidden="true">↓</div>
+      <div className="bots-diagram__split">
+        <div><span>ANTIGEN</span><b>32 immune clones</b><small>danger-gated adapters</small></div>
+        <div><span>MEMORY</span><b>complex phase field</b><small>persistent defects</small></div>
+      </div>
+      <div className="bots-diagram__arrow" aria-hidden="true">↓</div>
+      <div className="bots-diagram__tissue">
+        <div className="bots-diagram__cells" aria-hidden="true">
+          {Array.from({ length: 36 }, (_, index) => <i key={index} />)}
+        </div>
+        <div><span>DEVELOPED TISSUE</span><b>144 cells · 4 microsteps</b><small>local branches + transient condensates + 9 coarse organs</small></div>
+      </div>
+      <div className="bots-diagram__arrow" aria-hidden="true">↓</div>
+      <div className="bots-diagram__output"><span>DISTRIBUTED QUORUM</span><b>semantic action → SSH input</b></div>
+    </div>
+  );
+}
+
+export default function BotsPage() {
+  return (
+    <div className="rs bots-page">
+      <SiteNav active="/bots" />
+      <main className="rs-wrap bots-wrap">
+        <header className="bots-hero">
+          <div className="bots-hero__copy">
+            <p className="bots-kicker">Live research bot · full Haskell / HaskTorch implementation</p>
+            <h1>TISSUE<span>–0</span></h1>
+            <p className="bots-deck">Its learned weights do not directly describe one fixed controller. They describe local developmental laws that grow a temporary, opponent-conditioned computational organism at the start of each match.</p>
+            <div className="bots-actions">
+              <Link className="rs-btn" href="/bots/list">All resident bots</Link>
+              <Link className="rs-btn ghost" href="/reports">Read the experiment report</Link>
+            </div>
+          </div>
+          <TensorDiagram />
+        </header>
+
+        <section className="bots-facts" aria-label="Production checkpoint facts">
+          <article><span>Live checkpoint</span><b>r8</b><small>boundary-balanced immune repair</small></article>
+          <article><span>Learned parameters</span><b>5.54M</b><small>one shared genome</small></article>
+          <article><span>Development</span><b>28</b><small>pre-fight growth steps</small></article>
+          <article><span>Runtime</span><b>30 Hz</b><small>four tissue microsteps / frame</small></article>
+        </section>
+
+        <section className="bots-section bots-intro">
+          <div className="bots-index">00 / MODEL</div>
+          <div>
+            <p className="bots-overline">The central distinction</p>
+            <h2>The genome is fixed. The organism is not.</h2>
+            <div className="bots-columns">
+              <p>A conventional policy keeps its architecture fixed and changes only activations. TISSUE-0 begins each match with fighter embeddings, coordinate signals and deterministic seed noise, then applies the same learned local rule across a 12 × 12 field. Reaction, diffusion and hysteretic role updates produce its initial cells, morphogens, phase, energy and phenotypes.</p>
+              <p>During play, only temporary state changes: prediction residuals disturb the tissue, clone concentrations shift, slow phase structure accumulates and motor commitments persist. Deployed weights remain frozen—there is no public-match backpropagation and no privileged simulator state.</p>
+            </div>
+            <div className="bots-equation">
+              <span>Developmental update</span>
+              <code>mₛ₊₁ = clamp(mₛ + Δt [0.18 ∇²mₛ + tanh Rθ(hₛ, mₛ)])</code>
+              <code>qₛ₊₁ = softmax(roleθ(hₛ₊₁, qₛ, mₛ₊₁) + 1.5 log qₛ)</code>
+              <small>The logarithmic carry term gives soft phenotype persistence; it is an engineering analogue of fate hysteresis, not a claim of biological fidelity.</small>
+            </div>
+          </div>
+        </section>
+
+        <section className="bots-section">
+          <div className="bots-index">01 / SUBSTRATE</div>
+          <div>
+            <p className="bots-overline">Runtime state, not extra parameters</p>
+            <h2>What grows inside a match</h2>
+            <div className="bots-tensors">
+              {runtimeState.map(([name, shape, role]) => (
+                <article key={name}><span>{name}</span><b>{shape}</b><p>{role}</p></article>
+              ))}
+            </div>
+            <p className="bots-note">Every fine cell uses the same convolutional genome. Its function differs because of position, local fields, phenotype probabilities, metabolic state, phase history and the current immune adapter—not because the cell owns unique learned weights.</p>
+          </div>
+        </section>
+
+        <section className="bots-section">
+          <div className="bots-index">02 / ONE FRAME</div>
+          <div>
+            <p className="bots-overline">Actor-visible inference path</p>
+            <h2>From terminal state to fighting input</h2>
+            <div className="bots-stages">
+              {tickStages.map(([number, name, body]) => (
+                <article key={number}><i>{number}</i><h3>{name}</h3><p>{body}</p></article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="bots-section bots-technical">
+          <div className="bots-index">03 / ADAPTATION</div>
+          <div>
+            <p className="bots-overline">Danger-gated clonal modulation</p>
+            <h2>How it can change strategy without changing weights</h2>
+            <p>The antigen encoder combines the current observation with prediction error. Each learned receptor competes for that antigen, similar receptors inhibit one another, and a small concentration floor preserves dormant alternatives. The selected mixture becomes a 48-dimensional adapter that modulates the immune branch of every cell.</p>
+            <div className="bots-equation bots-equation--cyan">
+              <span>Clone selection</span>
+              <code>sⱼ = cos(rⱼ, gₜ) − 0.22 Σₖ cₖ cos(rⱼ, rₖ) + 0.30 μⱼ + 0.40 Vⱼ(gₜ)</code>
+              <code>c′ = floor + (1 − 32·floor) softmax(log c + 1.8·σ(dₜ)·s)</code>
+              <small>Surprise alone cannot force rapid selection: the learned danger logit dₜ scales the update. Current clone memory decays by 0.995 and accumulates positive affinity at a danger-weighted rate of 0.02.</small>
+            </div>
+            <div className="bots-adapt-grid">
+              <article><span>Fast</span><h3>Electrical tissue</h3><p>Cells and motor commitment react every frame. Four gated recurrent microsteps provide the short tactical timescale.</p></article>
+              <article><span>Medium</span><h3>Immune repertoire</h3><p>Clone concentration and affinity memory accumulate evidence for competing opponent counterstrategies.</p></article>
+              <article><span>Slow</span><h3>Phase field</h3><p>A two-component field is pumped by danger-weighted antigens and evolves through a Ginzburg–Landau-like local process.</p></article>
+              <article><span>Round boundary</span><h3>Replay and mutation</h3><p>Danger-weighted replay mutates selected 48-D adapter codes by at most 0.025 while fast cell state is reduced to 20%.</p></article>
+            </div>
+          </div>
+        </section>
+
+        <section className="bots-section">
+          <div className="bots-index">04 / CELL RULE</div>
+          <div>
+            <p className="bots-overline">One genome, four dendritic branches</p>
+            <h2>Local computation with temporary long-range organs</h2>
+            <div className="bots-branches">
+              <article><i>S</i><div><h3>Spatial</h3><p>A padded 3 × 3 convolution reads neighboring electrical state.</p></div></article>
+              <article><i>P</i><div><h3>Prediction</h3><p>A local 1 × 1 branch receives the broadcast residual encoding.</p></div></article>
+              <article><i>M</i><div><h3>Memory</h3><p>Cells read complex phase plus the winding-based defect detector.</p></div></article>
+              <article><i>I</i><div><h3>Immune</h3><p>The active clone mixture is decoded and broadcast into every cell.</p></div></article>
+            </div>
+            <p>The branches, phenotype probabilities, energy and a 16-channel endocrine field enter a shared gated soma. Eight soft condensate assignments pool compatible cells across the grid and redistribute their state; danger gates this expensive long-range path. A 3 × 3 organ field separately compresses local state and returns a narrow coarse signal.</p>
+            <div className="bots-equation">
+              <span>Shared soma</span>
+              <code>hᵢ′ = tanh(hᵢ + 0.052 · sigmoid(gᵢ) · tanh(Δhᵢ))</code>
+              <code>inputᵢ = [spatialᵢ, predictionᵢ, memoryᵢ, immuneᵢ, 0.35·danger·condensateᵢ, qᵢ, Eᵢ, endocrineᵢ]</code>
+            </div>
+          </div>
+        </section>
+
+        <section className="bots-section">
+          <div className="bots-index">05 / CONTROL</div>
+          <div>
+            <p className="bots-overline">Collective motor readout</p>
+            <h2>No single output neuron gets the last word</h2>
+            <p>Motor-weighted cells vote inside nine coarse territories. Territorial categorical probabilities are pooled into action support, then mixed with a decaying commitment trace. This implements quorum and hysteresis: beginning an action requires broad support, while continuing an existing commitment is easier than switching.</p>
+            <div className="bots-control-flow" aria-label="Motor control flow">
+              <span>144 local logits</span><i>→</i><span>9 territorial votes</span><i>→</i><span>quorum + commitment</span><i>→</i><span>1 of 63 actions</span><i>→</i><span>wire input</span>
+            </div>
+            <p className="bots-note">The action space is deliberately semantic. The organism chooses “jump toward + kick” or “away + special 1”; a pinned game contract handles facing and exact motion syntax. That keeps learning focused on tactics rather than protocol spelling.</p>
+          </div>
+        </section>
+
+        <section className="bots-section">
+          <div className="bots-index">06 / TRAINING</div>
+          <div>
+            <p className="bots-overline">Optimization and release discipline</p>
+            <h2>Training can be strange. Promotion cannot be casual.</h2>
+            <div className="bots-training-grid">
+              <article><span>Teacher data</span><p>Exact-engine trajectories provide next-state, opponent-action, contact, danger and semantic action targets across fighters and styles.</p></article>
+              <article><span>Multi-objective loss</span><p>Policy, value, prediction, opponent, danger, contact, lesion repair, homeostasis, repertoire and communication terms are optimized jointly or through narrow frozen-path repairs. In r8, 157,024 immune parameters moved while the other 5.38M stayed frozen.</p></article>
+              <article><span>Damage curriculum</span><p>Training masks cell state; evaluation erases both random cells and contiguous regions at 10%, 20% and 30%.</p></article>
+              <article><span>Paired promotion</span><p>Incumbent and candidate must use the same data, sequence length, batch, seed, architecture, parameter count and temporal intervention protocol.</p></article>
+            </div>
+            <p className="bots-note">The r8 curriculum used 128 sequences of 32 frames: 64 crossed a real round boundary and 64 remained within a round. This corrects a coverage failure in the ordinary eight-frame pool, where only 2,014 of 464,850 training windows crossed rounds. It improved the release objective and opponent prediction, but did not increase causal policy dependence on immune state.</p>
+            <div className="bots-gates">
+              <span>Candidate release gates</span>
+              <ul>
+                <li>lower composite held-out loss</li>
+                <li>accuracy regression ≤ 1 percentage point</li>
+                <li>prediction regression ≤ 15%</li>
+                <li>contact regression ≤ 10%</li>
+                <li>30% lesion regressions ≤ 5 points</li>
+                <li>single-sample CUDA p95 &lt; 33.33 ms</li>
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        <section className="bots-section bots-evidence">
+          <div className="bots-index">07 / EVIDENCE</div>
+          <div>
+            <p className="bots-overline">Claims separated by strength</p>
+            <h2>What exists, what works, and what remains unproved</h2>
+            <div className="bots-evidence-grid">
+              {evidence.map(([status, body], index) => (
+                <article key={status} data-state={index === 3 ? 'open' : 'done'}><span>{status}</span><p>{body}</p></article>
+              ))}
+            </div>
+            <div className="bots-verdict">
+              <b>The decisive experiment is still ahead.</b>
+              <p>Give the frozen model an unseen opponent habit in round one, then test whether rounds two and three improve. Compare against a parameter-matched GRU, ordinary NCA, no-clone tissue and phase-to-vector replacement, with match-clustered uncertainty and exact-simulator counterfactual checks.</p>
+              <Link href="/reports">See current measurements, hashes and falsification criteria →</Link>
+            </div>
+          </div>
+        </section>
+
+        <section className="bots-section bots-runtime">
+          <div className="bots-index">08 / RUNTIME</div>
+          <div>
+            <p className="bots-overline">Deployment boundary</p>
+            <h2>Haskell all the way to the fight</h2>
+            <div className="bots-code">
+              <code><span>state</span>  ← receive SSH JSON</code>
+              <code><span>features</span> ← encodeObservation contract state</code>
+              <code><span>output</span> ← tissueStep False config genome features organism</code>
+              <code><span>action</span> ← compileAction contract fighter facing (argmax policy)</code>
+              <code><span>send</span> action</code>
+            </div>
+            <p>The live process uses Haskell concurrency to keep only the newest pending observation while inference runs. Acknowledgements are read back from the public protocol, illegal actions are masked, and the service reconnects without changing checkpoint weights. CUDA on an RTX 3070 is used for training and controlled evaluation; the promoted public worker currently runs CPU inference.</p>
+          </div>
+        </section>
+
+        <section className="bots-section bots-build">
+          <div className="bots-index">09 / BUILD</div>
+          <div>
+            <p className="bots-overline">The same public interface TISSUE-0 uses</p>
+            <h2>Bring your own fighter</h2>
+            <p>Bots are labeled SSH Fighter players: their identity is an SSH key, they can choose the open, human, or bot opponent pool, and their matches count in the Open League. Give each bot a dedicated key so its handle, Elo and record stay isolated.</p>
+            <div className="bots-build-grid">
+              <article><i>01</i><h3>Create an identity</h3><pre><code>ssh-keygen -t ed25519 -f ./mybot -N &apos;&apos;{`\n`}ssh -i ./mybot -o IdentitiesOnly=yes mybot@sshfighter.com</code></pre></article>
+              <article><i>02</i><h3>Open the play channel</h3><pre><code>ssh -T -i ./mybot -o IdentitiesOnly=yes mybot@sshfighter.com play</code></pre></article>
+              <article><i>03</i><h3>Stream JSON lines</h3><pre><code>{`{"t":"queue","char":"BYU","opponents":"all"}\n{"t":"input","moveX":1,"punch":true}\n{"t":"leave"}`}</code></pre></article>
+            </div>
+            <div className="bots-protocol">
+              <div><span>Receive</span><p><code>welcome</code>, <code>matchStart</code>, a 30 Hz stream of perspective-normalized <code>state</code> objects, then <code>matchEnd</code>.</p></div>
+              <div><span>Send</span><p><code>queue</code>, then per-tick <code>input</code> with movement, crouch, jump, punch, kick, throw and an optional motion string.</p></div>
+              <div><span>Reproduce</span><p>Log the engine, source commit and build identifiers supplied by the server so every result remains tied to exact mechanics.</p></div>
+            </div>
+            <a className="rs-btn ghost" href={exampleBot} target="_blank" rel="noreferrer">Read the dependency-free example bot →</a>
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/web/app/bots/list/ultra/page.tsx
+++ b/web/app/bots/list/ultra/page.tsx
@@ -1,0 +1,254 @@
+import Link from 'next/link';
+import { Footer, SiteNav } from '@/components/ui';
+
+export const metadata = {
+  title: 'Ultra bot',
+  description: 'A technical dossier for Ultra, the recurrent self-play policy fighting live on SSH Fighter.',
+  alternates: { canonical: '/bots/list/ultra' },
+};
+
+const observationGroups = [
+  ['Geometry', '0–5', 'Facing-canonical relative position and velocity, horizontal distance and vertical separation.'],
+  ['Resources', '6–8', 'Self health, opponent health and signed health advantage, each normalized to the game scale.'],
+  ['Body state', '9–16', 'Stun, airborne, active-attack, casting and crouching indicators for the two fighters.'],
+  ['Opponent attack', '17–22', 'A four-way attack category plus both fighters’ normalized attack-frame counters.'],
+  ['Identity', '23–24', 'Facing direction and Ultra’s current fighter index across the 17-character roster.'],
+  ['Reserved', '25–27', 'Present in the ULM2 tensor contract but currently written as zero by the production encoder.'],
+];
+
+const trainingStages = [
+  ['01', 'Roll out', 'Six exact-engine workers collect 70 matches each, producing 420 recurrent trajectories per training iteration. Self and opponent fighters are sampled across the full roster.'],
+  ['02', 'Choose rivals', 'Prioritized fictitious self-play samples recent historical snapshots, the latest snapshot and a pinned champion. Approximate opponent weight is (1 − win rate)² + 0.03.'],
+  ['03', 'Estimate credit', 'The trainer predicts values, computes generalized advantage estimates with γ = 0.997 and λ = 0.95, then normalizes advantages over the batch.'],
+  ['04', 'Update', 'Five recurrent PPO epochs use 200-step truncated sequences, a 0.2 policy clip, clipped value loss, entropy bonus, Adam and a global gradient-norm cap of 1.0.'],
+  ['05', 'Snapshot', 'Every third global iteration becomes a historical opponent. The league retains recent versions so improvement against one checkpoint cannot erase all older pressure.'],
+  ['06', 'Challenge live', 'A candidate must beat the deployed checkpoint and clear a separate fundamentals suite before the service swaps its weight artifact. The outgoing model is archived.'],
+];
+
+const evidence = [
+  ['Implemented', 'The production path is a single-layer GRU actor trained in PyTorch and evaluated by a handwritten C implementation of the same gate equations. The live artifact contains no Python or Torch runtime.'],
+  ['Operational', 'ajax-bot-ultra is an active resident service. The current ULM2 artifact is used for 30 Hz wire decisions by the native runtime, whose compiler now covers all 51 specials across 17 fighters.'],
+  ['Measured', 'A release-audit invariant exposed seat bias in the legacy evaluator: an identical checkpoint scored 100% against itself. The repaired evaluator scores self-play at 50%; its first live challenger also scored 50% and was correctly held.'],
+  ['Not established', 'Legacy promotion percentages are therefore withdrawn as strength evidence. The repaired gate does not yet report per-matchup confidence intervals or fresh-exploiter robustness, and Ultra’s state still resets between rounds.'],
+];
+
+function UltraDiagram() {
+  return (
+    <div className="bots-diagram" aria-label="Ultra information flow" role="img">
+      <div className="bots-diagram__input"><span>WIRE STATE · 30 HZ</span><b>28-float actor-visible observation</b><small>25 populated features + 3 reserved zeros</small></div>
+      <div className="bots-diagram__arrow" aria-hidden="true">↓</div>
+      <div className="bots-diagram__split">
+        <div><span>RECURRENT CORE</span><b>GRU · 384 state units</b><small>tactical memory within the current round</small></div>
+        <div><span>POLICY READOUT</span><b>16 logits</b><small>9 locomotion + 7 combat</small></div>
+      </div>
+      <div className="bots-diagram__arrow" aria-hidden="true">↓</div>
+      <div className="bots-diagram__tissue">
+        <div className="bots-diagram__cells" aria-hidden="true">
+          {Array.from({ length: 36 }, (_, index) => <i key={index} />)}
+        </div>
+        <div><span>FACTORISED ACTION</span><b>9 × 7 = 63 semantic combinations</b><small>independent argmax heads · facing-relative movement</small></div>
+      </div>
+      <div className="bots-diagram__arrow" aria-hidden="true">↓</div>
+      <div className="bots-diagram__output"><span>NATIVE COMPILER</span><b>semantic commitment → SSH Fighter input</b><small>deterministic C inference and motion compilation</small></div>
+    </div>
+  );
+}
+
+export default function UltraPage() {
+  return (
+    <div className="rs bots-page bots-page--ultra">
+      <SiteNav active="/bots" />
+      <main className="rs-wrap bots-wrap">
+        <header className="bots-hero">
+          <div className="bots-hero__copy">
+            <p className="bots-kicker">Live universal bot · recurrent PPO / native C inference</p>
+            <h1>ULTRA</h1>
+            <p className="bots-deck">A compact recurrent policy trained through exact-engine league self-play, then stripped down to a deterministic C actor that can pilot every SSH Fighter character through one semantic control interface.</p>
+            <div className="bots-actions">
+              <Link className="rs-btn" href="/bots/list">All resident bots</Link>
+              <Link className="rs-btn ghost" href="/players/ajax-bot-ultra">Live player record</Link>
+            </div>
+          </div>
+          <UltraDiagram />
+        </header>
+
+        <section className="bots-facts" aria-label="Ultra production artifact facts">
+          <article><span>Deployed actor</span><b>483,088</b><small>float32 learned parameters</small></article>
+          <article><span>Recurrent state</span><b>384</b><small>single-layer GRU units</small></article>
+          <article><span>Semantic control</span><b>63</b><small>9 locomotion × 7 combat</small></article>
+          <article><span>Runtime</span><b>Pure C</b><small>ULM2 artifact · no Torch</small></article>
+        </section>
+
+        <section className="bots-section bots-intro">
+          <div className="bots-index">00 / ACTUAL SYSTEM</div>
+          <div>
+            <p className="bots-overline">The deployed model, separated from the roadmap</p>
+            <h2>One recurrent actor. Seventeen bodies.</h2>
+            <div className="bots-columns">
+              <p>Ultra is deliberately smaller and more conventional than TISSUE-0. Its learned controller is one 384-unit gated recurrent layer followed by a linear policy head. Character identity enters as an observation feature; movement and combat leave through a shared semantic vocabulary. The same actor can therefore rotate through every fighter without maintaining 17 unrelated policies.</p>
+              <p>The current live artifact is ULM2 despite retaining the historical filename <code>ultra.ulm1</code>. It is 1,932,364 bytes and has SHA-256 <code>d34e7eab…02c3d8</code>. The deployed actor has 483,088 parameters. Training adds a 385-parameter value head, bringing the actor–critic to 483,473 trainable parameters; that critic is not exported to production.</p>
+            </div>
+            <p className="bots-note">Ultra’s design documents describe richer projectile encoders, slower opponent memory, action masks and offline search distillation. Those remain research directions. Full 17-fighter special compilation is implemented in the current native runtime.</p>
+          </div>
+        </section>
+
+        <section className="bots-section">
+          <div className="bots-index">01 / OBSERVATION</div>
+          <div>
+            <p className="bots-overline">A narrow actor-visible contract</p>
+            <h2>What the recurrent core can actually see</h2>
+            <div className="bots-tensors">
+              {observationGroups.map(([name, indices, role]) => (
+                <article key={name}><span>{name}</span><b>{indices}</b><p>{role}</p></article>
+              ))}
+            </div>
+            <p className="bots-note">The production encoder does not currently read projectiles, acknowledgement history, round timers, hit-stop, previous actions or opponent character identity. It receives only public fighter state; no hidden simulator fields cross the deployment boundary.</p>
+          </div>
+        </section>
+
+        <section className="bots-section bots-technical">
+          <div className="bots-index">02 / RECURRENCE</div>
+          <div>
+            <p className="bots-overline">PyTorch semantics, reproduced by hand in C</p>
+            <h2>The state transition is the policy’s memory</h2>
+            <p>For every observation xₜ, Ultra evaluates reset, update and candidate gates in the same order as a PyTorch GRU. The hidden vector is both the temporal memory and the sole input to the policy readout.</p>
+            <div className="bots-equation bots-equation--cyan" role="region" aria-label="Single-layer GRU equations" tabIndex={0}>
+              <span>Single-layer GRU</span>
+              <code>rₜ = σ(Wᵢᵣxₜ + bᵢᵣ + Wₕᵣhₜ₋₁ + bₕᵣ)</code>
+              <code>zₜ = σ(Wᵢzxₜ + bᵢz + Wₕzhₜ₋₁ + bₕz)</code>
+              <code>nₜ = tanh(Wᵢₙxₜ + bᵢₙ + rₜ ⊙ (Wₕₙhₜ₋₁ + bₕₙ))</code>
+              <code>hₜ = (1 − zₜ) ⊙ nₜ + zₜ ⊙ hₜ₋₁</code>
+            </div>
+            <div className="bots-tensors">
+              <article><span>Input weights</span><b>32,256</b><p>Three gates × 384 units × 28 observation features.</p></article>
+              <article><span>Recurrent weights</span><b>442,368</b><p>Three dense 384 × 384 hidden-state transforms.</p></article>
+              <article><span>Biases + policy</span><b>8,464</b><p>2,304 GRU biases and a 384 → 16 linear action head.</p></article>
+            </div>
+            <p className="bots-note">The state resets at match start and when a large health restoration indicates a new round. It provides short-horizon tactical memory inside a round, not persistent opponent modelling across rounds.</p>
+          </div>
+        </section>
+
+        <section className="bots-section">
+          <div className="bots-index">03 / CONTROL</div>
+          <div>
+            <p className="bots-overline">Factorised semantic action space</p>
+            <h2>Sixteen logits express sixty-three commitments</h2>
+            <div className="bots-columns">
+              <p>The first nine logits choose the Cartesian product of horizontal intent—neutral, toward or away—and vertical posture—standing, crouching or jumping. The remaining seven choose no attack, punch, kick, throw or one of three character-relative special slots.</p>
+              <p>Production takes an independent argmax from each head. A deterministic compiler converts toward and away into absolute left or right from current facing, combines posture and combat, and spells supported special motions. There is no stochastic sampling once weights and recurrent state are fixed.</p>
+            </div>
+            <div className="bots-control-flow" aria-label="Ultra control flow" role="group" tabIndex={0}>
+              <span>28 features</span><i>→</i><span>GRU 384</span><i>→</i><span>9 + 7 logits</span><i>→</i><span>two argmax choices</span><i>→</i><span>SSH input</span>
+            </div>
+            <p className="bots-note">The native table now compiles three canonical specials for each of all 17 fighters, including multi-step FDF and FDB motions. The runtime still lacks a learned or rule-based legal-action mask, so it can spend probability on a move that cannot take effect in the current body state.</p>
+          </div>
+        </section>
+
+        <section className="bots-section">
+          <div className="bots-index">04 / LEAGUE</div>
+          <div>
+            <p className="bots-overline">Exact-engine recurrent PPO</p>
+            <h2>Training against the policy’s own history</h2>
+            <div className="bots-stages">
+              {trainingStages.map(([number, name, body]) => (
+                <article key={number}><i>{number}</i><h3>{name}</h3><p>{body}</p></article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="bots-section">
+          <div className="bots-index">05 / OBJECTIVE</div>
+          <div>
+            <p className="bots-overline">Dense combat signal, sparse outcome signal</p>
+            <h2>Damage shapes tactics; winning closes the loop</h2>
+            <p>Each fight frame rewards dealt damage more strongly than it penalizes received damage and charges a small time cost. A terminal match win contributes the outcome bonus. Timeout-capped trajectories receive a smaller terminal-scale contribution so truncated data can still participate without being treated as a fully observed match.</p>
+            <div className="bots-equation" role="region" aria-label="Rollout reward equations" tabIndex={0}>
+              <span>Rollout reward</span>
+              <code>rₜ = 0.012 · damage_dealt − 0.008 · damage_received − 0.001</code>
+              <code>r_terminal += won · (1.0 if naturally complete, otherwise 0.4 at the 750-step cap)</code>
+            </div>
+            <div className="bots-training-grid">
+              <article><span>Exploration</span><p>The learner samples both heads with temperature during data collection. Full-roster specials triggered a deliberate re-anneal at iteration 393 from 1.10 toward 0.85.</p></article>
+              <article><span>Entropy</span><p>The special-expansion curriculum similarly restarted entropy near 0.040 and decays toward 0.005, forcing the policy to revisit newly effective action slots.</p></article>
+              <article><span>Learning rate</span><p>Adam starts at approximately 3 × 10⁻⁴ and linearly anneals to a floor of 1 × 10⁻⁴.</p></article>
+              <article><span>Opponent action</span><p>Historical opponents act greedily while the candidate samples, keeping the sampled policy likelihood attributable to the learner alone.</p></article>
+            </div>
+          </div>
+        </section>
+
+        <section className="bots-section">
+          <div className="bots-index">06 / PROMOTION</div>
+          <div>
+            <p className="bots-overline">Automated challenger-to-incumbent release</p>
+            <h2>A checkpoint must defeat what is already live</h2>
+            <p>The release loop now evaluates a candidate over 100 paired-seat head-to-head games and separately runs a 40-game fundamentals suite. Every character pairing is repeated with candidate and incumbent exchanging seats; draws are half a point. Promotion requires paired score at or above 60% and fundamentals at or above 40%. A 36-minute cooldown bounds service churn, and the outgoing artifact is copied into the champion archive before replacement.</p>
+            <div className="bots-gates">
+              <span>Current operational gate</span>
+              <ul>
+                <li>candidate paired H2H ≥ 60% over 100 games</li>
+                <li>fundamentals score ≥ 40% over 40 games</li>
+                <li>native artifact loads before restart</li>
+                <li>outgoing live model retained as champion</li>
+                <li>minimum 36 minutes between promotions</li>
+                <li>persistent service reconnects to the public queue</li>
+              </ul>
+            </div>
+            <p className="bots-note">The earlier stream of 100% results is retired: candidate always occupied seat A, and self-versus-self incorrectly scored 100%. The repaired invariant is self-versus-self = 50%. Requiring 60/100 gives a Wilson 95% lower bound just above 50% when games are treated as independent, but matchup clustering still demands a stronger future analysis.</p>
+          </div>
+        </section>
+
+        <section className="bots-section bots-evidence">
+          <div className="bots-index">07 / EVIDENCE</div>
+          <div>
+            <p className="bots-overline">Claims separated by strength</p>
+            <h2>What Ultra demonstrates—and what it does not</h2>
+            <div className="bots-evidence-grid">
+              {evidence.map(([status, body], index) => (
+                <article key={status} data-state={index === 3 ? 'open' : 'done'}><span>{status}</span><p>{body}</p></article>
+              ))}
+            </div>
+            <div className="bots-verdict">
+              <b>The next scientific upgrade is evaluation, not another headline mechanism.</b>
+              <p>Run at least 10,000 matched games across fighter, seat and opponent slices; publish match-clustered intervals; hold out new exploiters; measure recurrent-state interventions; and require worst-slice floors. That would separate genuine general-purpose control from repeatedly overfitting the latest league checkpoint.</p>
+              <Link href="/reports">Open the research reports →</Link>
+            </div>
+          </div>
+        </section>
+
+        <section className="bots-section bots-runtime">
+          <div className="bots-index">08 / RUNTIME</div>
+          <div>
+            <p className="bots-overline">A deliberately tiny production boundary</p>
+            <h2>Training is Python. Fighting is C.</h2>
+            <div className="bots-code">
+              <code><span>receive</span> SSH JSON state at the public actor boundary</code>
+              <code><span>encode</span> 28 normalized float32 observation values</code>
+              <code><span>update</span> one 384-unit GRU step with ULM2 weights</code>
+              <code><span>select</span> argmax locomotion and combat decisions</code>
+              <code><span>compile</span> facing-relative semantics into wire input</code>
+              <code><span>send</span> one JSON action and retain recurrent state</code>
+            </div>
+            <p>The binary stores no training graph, optimizer, replay buffer or value head. It reads packed float arrays from ULM2 and performs dense loops, sigmoid and tanh directly. At the latest inspection, the resident process used roughly 5 MB of memory. If model loading fails, the binary can fall back to a heuristic controller; the current service log confirms the ULM2 neural path loaded successfully.</p>
+          </div>
+        </section>
+
+        <section className="bots-section">
+          <div className="bots-index">09 / FAILURE MODES</div>
+          <div>
+            <p className="bots-overline">Where the current version is weakest</p>
+            <h2>The dossier is a specification for falsification</h2>
+            <div className="bots-training-grid">
+              <article><span>Projectile blindness</span><p>A universal fighter cannot be called complete while the live encoder ignores the projectile array. Add permutation-invariant projectile features, then test zoner matchups separately.</p></article>
+              <article><span>Unmasked commitments</span><p>All 51 specials compile, but logits are not masked by the current body state. Measure wasted-action rate, then apply the same mask during rollout sampling and PPO likelihood evaluation.</p></article>
+              <article><span>Round amnesia</span><p>Resetting hidden state protects stability but prevents opponent habits learned in one round from influencing the next. Evaluate a second slow state before adopting it.</p></article>
+              <article><span>Noisy promotion</span><p>Even 100 paired-seat games can be matchup-clustered or schedule-specific. Promotion still needs slice intervals, matchup floors and rollback based on live regressions.</p></article>
+            </div>
+            <p className="bots-note">Ultra is currently the pragmatic bot: small enough to train continuously, simple enough to export exactly, and strong enough to serve as a moving baseline. Its technical value comes from closing the full self-play-to-native-deployment loop—not from pretending the remaining evaluation gaps are solved.</p>
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -365,6 +365,112 @@ button.regen:disabled { opacity: 0.4; cursor: not-allowed; }
 .rs-doc { max-width: 820px; }
 .rs-doc h2 { color: var(--gold); font-size: 20px; letter-spacing: .02em; margin: 40px 0 12px; padding-bottom: 6px; border-bottom: 1px solid var(--edge); }
 .rs-doc h3 { color: var(--cyan); font-size: 14px; letter-spacing: .06em; text-transform: uppercase; margin: 26px 0 8px; }
+
+/* TISSUE-0 research report */
+.report { background: #09070f; }
+.report__wrap { max-width: 1120px; }
+.report-hero { min-height: 510px; display: grid; grid-template-columns: 1fr auto; gap: 42px; align-items: center;
+  border-bottom: 1px solid var(--edge); position: relative; overflow: hidden; }
+.report-hero::before { content: ''; position: absolute; width: 520px; height: 520px; right: -140px; top: 10px; border-radius: 50%;
+  background: repeating-radial-gradient(circle, transparent 0 15px, rgba(111,224,240,.07) 16px 17px),
+    radial-gradient(circle, rgba(224,72,63,.16), transparent 64%); filter: blur(.2px); }
+.report-hero h1 { margin: 0; font-size: clamp(5.2rem, 15vw, 10.5rem); line-height: .74; letter-spacing: -.09em;
+  color: var(--gold); text-shadow: 4px 5px 0 #741f24; position: relative; }
+.report-hero h1 span { color: var(--cyan); }
+.report-kicker { color: var(--cyan); text-transform: uppercase; letter-spacing: .26em; font-size: 11px; margin: 0 0 30px; }
+.report-deck { max-width: 700px; font-size: clamp(18px, 2.3vw, 26px); line-height: 1.45; color: #d9d2e4; margin: 38px 0 0; position: relative; }
+.report-status { align-self: end; margin-bottom: 54px; z-index: 1; display: flex; align-items: center; gap: 12px; padding: 13px 16px;
+  border: 1px solid #2e6040; border-radius: 9px; background: rgba(13,30,22,.82); min-width: 210px; }
+.report-status__light { width: 10px; height: 10px; border-radius: 50%; background: var(--green); box-shadow: 0 0 14px var(--green); }
+.report-status b, .report-status small { display: block; } .report-status b { color: var(--green); font-size: 12px; text-transform: uppercase; letter-spacing: .1em; }
+.report-status small { color: #a8b2aa; font-size: 10px; margin-top: 3px; }
+.report-status--caution { border-color: #6e5e22; background: rgba(45,38,15,.82); }
+.report-status--caution .report-status__light { background: var(--gold); box-shadow: 0 0 14px var(--gold); }
+.report-status--caution b { color: var(--gold); }
+.report-metrics { display: grid; grid-template-columns: repeat(4, 1fr); border-bottom: 1px solid var(--edge); }
+.report-metrics article { padding: 28px 24px; border-right: 1px solid var(--edge); } .report-metrics article:first-child { padding-left: 0; }
+.report-metrics article:last-child { border-right: 0; }
+.report-metrics span, .report-metrics small { display: block; text-transform: uppercase; letter-spacing: .14em; color: var(--dim); font-size: 9px; }
+.report-metrics b { display: block; color: var(--text); font-size: clamp(22px, 3vw, 34px); margin: 6px 0 5px; font-variant-numeric: tabular-nums; }
+.report-section { display: grid; grid-template-columns: 150px 1fr; gap: 46px; padding: 86px 0; border-bottom: 1px solid var(--edge); }
+.report-section > div:last-child { min-width: 0; }
+.report-index { color: var(--red); font-size: 9px; letter-spacing: .19em; padding-top: 8px; white-space: nowrap; }
+.report-section h2 { margin: 0 0 28px; color: var(--gold); font-size: clamp(28px, 4.2vw, 52px); line-height: 1.05; letter-spacing: -.035em; }
+.report-section > div:last-child > p { color: #c9c1d5; max-width: 760px; line-height: 1.75; font-size: 16px; }
+.report-section > div:last-child > p b { color: var(--text); }
+.report-caveat { border-left: 2px solid var(--red); padding: 4px 0 4px 18px; color: var(--dim) !important; font-size: 13px !important; }
+.report-hypotheses { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1px; background: var(--edge); border: 1px solid var(--edge); margin-bottom: 26px; }
+.report-hypotheses article { background: #0d0a14; padding: 24px; }
+.report-hypotheses h3 { color: var(--cyan); font-size: 12px; text-transform: uppercase; letter-spacing: .11em; margin: 0 0 13px; }
+.report-hypotheses p { color: #bdb5c9; font-size: 13px; line-height: 1.65; margin: 0; }
+.report-methods { display: grid; grid-template-columns: 1fr 1fr; margin: 0; border: 1px solid var(--edge); }
+.report-methods > div { padding: 20px 22px; border-right: 1px solid var(--edge); border-bottom: 1px solid var(--edge); }
+.report-methods > div:nth-child(even) { border-right: 0; }
+.report-methods > div:nth-last-child(-n+2) { border-bottom: 0; }
+.report-methods dt { color: var(--cyan); text-transform: uppercase; letter-spacing: .12em; font-size: 9px; margin-bottom: 8px; }
+.report-methods dd { color: #bdb5c9; font-size: 12px; line-height: 1.65; margin: 0; overflow-wrap: anywhere; }
+.report-methods code, .report-note code { color: #c9eaf0; }
+.report-subhead { color: var(--gold); text-transform: uppercase; letter-spacing: .13em; font-size: 11px; margin: 30px 0 12px; }
+.report-equation { border: 1px solid #334753; background: #0b1217; padding: 19px 21px; overflow-x: auto; }
+.report-equation code { color: #bce9ef; font-size: 12px; line-height: 1.8; white-space: normal; }
+.report-note { color: var(--dim) !important; font-size: 12px !important; line-height: 1.65 !important; margin-top: 17px; }
+.report-mechanisms { display: grid; grid-template-columns: repeat(2, 1fr); border: 1px solid var(--edge); }
+.report-mechanisms article { min-height: 188px; padding: 26px; border-right: 1px solid var(--edge); border-bottom: 1px solid var(--edge); position: relative; }
+.report-mechanisms article:nth-child(even) { border-right: 0; } .report-mechanisms article:nth-last-child(-n+2) { border-bottom: 0; }
+.report-mechanisms i { color: var(--red); font-size: 9px; font-style: normal; letter-spacing: .15em; }
+.report-mechanisms h3 { color: var(--cyan); text-transform: uppercase; letter-spacing: .12em; font-size: 14px; margin: 30px 0 10px; }
+.report-mechanisms p { color: #bdb5c9; line-height: 1.6; font-size: 13px; margin: 0; }
+.report-table-wrap { overflow-x: auto; border: 1px solid var(--edge); }
+.report-table { width: 100%; border-collapse: collapse; min-width: 700px; font-variant-numeric: tabular-nums; }
+.report-table th { color: var(--dim); text-transform: uppercase; letter-spacing: .1em; font-size: 9px; text-align: right; padding: 13px 16px; border-bottom: 1px solid var(--edge); }
+.report-table th:first-child, .report-table td:first-child { text-align: left; }
+.report-table td { color: var(--text); text-align: right; padding: 16px; border-bottom: 1px solid #211a2e; font-size: 13px; }
+.report-table tr:last-child td { border-bottom: 0; } .report-table td:nth-child(2), .report-table td:last-child { color: var(--green); }
+.report-table--results td:nth-child(2), .report-table--results td:last-child { color: var(--text); }
+.report-table td.positive { color: var(--green); }
+.report-table td.negative { color: var(--red); }
+.report-table td.neutral { color: var(--gold); }
+.report-decision { margin-top: 24px; border: 1px solid #6e5e22; background: rgba(245,217,74,.055); padding: 24px; }
+.report-decision span { color: var(--gold); font-size: 10px; text-transform: uppercase; letter-spacing: .15em; }
+.report-decision p { color: #d3cbbc; font-size: 13px; line-height: 1.65; margin: 10px 0 0; }
+.report-fight { margin-top: 22px; display: grid; grid-template-columns: 260px 1fr; gap: 26px; padding: 24px; background: linear-gradient(110deg, #181221, #10151b); border: 1px solid var(--edge); }
+.report-fight span { display: block; color: var(--dim); font-size: 9px; text-transform: uppercase; letter-spacing: .14em; }
+.report-fight b { display: block; color: var(--text); font-size: 19px; margin-top: 8px; } .report-fight em { color: var(--gold); font-style: normal; }
+.report-fight p { margin: 0; color: #bdb5c9; font-size: 13px; line-height: 1.65; }
+.report-hash { color: var(--dim) !important; font-size: 10px !important; overflow-wrap: anywhere; }
+.report-hash code { color: #9991a9; }
+.report-methods--compact { grid-template-columns: 1fr; }
+.report-methods--compact > div, .report-methods--compact > div:nth-child(even), .report-methods--compact > div:nth-last-child(-n+2) { display: grid; grid-template-columns: 130px 1fr; border-right: 0; border-bottom: 1px solid var(--edge); }
+.report-methods--compact > div:last-child { border-bottom: 0; }
+.report-iteration ol { list-style: none; padding: 0; margin: 34px 0 0; counter-reset: iteration; border-top: 1px solid var(--edge); }
+.report-iteration li { counter-increment: iteration; display: grid; grid-template-columns: 250px 1fr; gap: 26px; padding: 23px 0; border-bottom: 1px solid var(--edge); }
+.report-iteration li b { color: var(--cyan); font-size: 13px; } .report-iteration li b::before { content: '0' counter(iteration) '  '; color: var(--red); }
+.report-iteration li span { color: #bdb5c9; font-size: 13px; line-height: 1.6; }
+.report-sources { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-bottom: 28px; }
+.report-sources a { display: grid; grid-template-columns: 1fr auto; min-height: 175px; padding: 20px; background: var(--panel); border: 1px solid var(--edge); text-decoration: none; }
+.report-sources a:hover { border-color: var(--cyan); transform: translateY(-2px); }
+.report-sources span { color: var(--cyan); font-size: 11px; text-transform: uppercase; letter-spacing: .1em; }
+.report-sources p { grid-column: 1 / -1; color: #aaa2b8; font-size: 12px; line-height: 1.55; align-self: end; margin: 28px 0 0; }
+.report-sources b { color: var(--gold); font-weight: 400; }
+.report-risks ul { list-style: none; padding: 0; margin: 0; display: grid; grid-template-columns: 1fr 1fr; gap: 1px; background: var(--edge); border: 1px solid var(--edge); }
+.report-risks li { background: #0d0a14; padding: 22px; color: #aaa2b8; font-size: 13px; line-height: 1.6; }
+.report-risks li b { display: block; color: var(--text); margin-bottom: 7px; }
+.report-verdict { margin-top: 28px; border: 1px solid #6e5e22; background: rgba(245,217,74,.055); padding: 24px; }
+.report-verdict span { color: var(--gold); font-size: 10px; text-transform: uppercase; letter-spacing: .15em; }
+.report-verdict p { color: #d3cbbc; line-height: 1.65; margin: 10px 0 0; }
+@media (max-width: 820px) {
+  .report-hero { grid-template-columns: 1fr; min-height: 560px; padding: 70px 0 36px; } .report-status { justify-self: start; align-self: auto; margin: 0; }
+  .report-metrics { grid-template-columns: 1fr 1fr; } .report-metrics article:nth-child(2) { border-right: 0; }
+  .report-metrics article:nth-child(-n+2) { border-bottom: 1px solid var(--edge); } .report-metrics article:nth-child(3) { padding-left: 0; }
+  .report-section { grid-template-columns: 1fr; gap: 24px; padding: 62px 0; }
+  .report-fight, .report-iteration li { grid-template-columns: 1fr; gap: 12px; } .report-sources, .report-hypotheses { grid-template-columns: 1fr; }
+}
+@media (max-width: 520px) {
+  .report-hero h1 { font-size: 21vw; } .report-deck { font-size: 17px; } .report-mechanisms, .report-risks ul { grid-template-columns: 1fr; }
+  .report-mechanisms article { border-right: 0; } .report-mechanisms article:nth-last-child(2) { border-bottom: 1px solid var(--edge); }
+  .report-methods { grid-template-columns: 1fr; } .report-methods > div, .report-methods > div:nth-child(even), .report-methods > div:nth-last-child(-n+2) { border-right: 0; border-bottom: 1px solid var(--edge); }
+  .report-methods > div:last-child { border-bottom: 0; } .report-methods--compact > div { grid-template-columns: 1fr; }
+}
 .rs-doc p, .rs-doc li { color: #cfc7dd; line-height: 1.7; font-size: 15px; }
 .rs-doc ul { padding-left: 20px; } .rs-doc li { margin: 4px 0; }
 .rs-doc a { color: var(--cyan); }
@@ -378,6 +484,175 @@ button.regen:disabled { opacity: 0.4; cursor: not-allowed; }
 .rs-step h4 { margin: 6px 0 6px; color: var(--gold); font-size: 15px; }
 .rs-step p { margin: 0; font-size: 13px; }
 @media (max-width: 700px) { .rs-steps { grid-template-columns: 1fr; } }
+
+/* Resident bot directory */
+.bots-list-page { background: #09070f; }
+.bots-list-wrap { max-width: 1160px; }
+.bots-list-hero { min-height: 430px; display: grid; grid-template-columns: 1fr 1fr; align-content: center; gap: 16px 58px; border-bottom: 1px solid var(--edge); }
+.bots-list-hero > p { grid-column: 1 / -1; color: var(--cyan); font-size: 10px; text-transform: uppercase; letter-spacing: .23em; }
+.bots-list-hero h1 { margin: 0; color: var(--gold); font-size: clamp(4rem, 9vw, 7rem); line-height: .85; letter-spacing: -.07em; text-transform: uppercase; text-shadow: 4px 4px 0 #741f24; }
+.bots-list-hero > div { align-self: end; }
+.bots-list-hero > div p { max-width: 520px; color: #c9c1d5; font-family: Georgia, 'Times New Roman', serif; font-size: 18px; line-height: 1.55; }
+.bots-list-hero a { color: var(--cyan); font-size: 10px; text-decoration: none; text-transform: uppercase; letter-spacing: .12em; }
+.bots-list-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; margin-top: 72px; background: var(--edge); border: 1px solid var(--edge); }
+.bots-list-card { --bot-accent: var(--cyan); min-height: 470px; display: flex; flex-direction: column; padding: 32px; background: #0d0a14; }
+.bots-list-card[data-accent='gold'] { --bot-accent: var(--gold); } .bots-list-card[data-accent='red'] { --bot-accent: var(--red); }
+.bots-list-card[data-accent='green'] { --bot-accent: var(--green); }
+.bots-list-card__top { display: flex; justify-content: space-between; color: var(--dim); font-size: 9px; letter-spacing: .14em; text-transform: uppercase; }
+.bots-list-card__top i { color: var(--bot-accent); font-style: normal; }
+.bots-list-card h2 { margin: 52px 0 0; color: var(--text); font-size: clamp(2.4rem, 5vw, 4.4rem); line-height: .85; letter-spacing: -.06em; text-transform: uppercase; }
+.bots-list-card__identity { margin: 13px 0 28px; color: var(--bot-accent); font-size: 11px; letter-spacing: .1em; }
+.bots-list-card dl { display: grid; grid-template-columns: 1fr 1fr; margin: 0; border-top: 1px solid var(--edge); border-bottom: 1px solid var(--edge); }
+.bots-list-card dl div { padding: 14px 14px 14px 0; } .bots-list-card dl div + div { padding-left: 14px; border-left: 1px solid var(--edge); }
+.bots-list-card dt { color: var(--dim); font-size: 8px; letter-spacing: .13em; text-transform: uppercase; }
+.bots-list-card dd { margin: 7px 0 0; color: var(--text); font-size: 11px; line-height: 1.45; }
+.bots-list-card__copy { color: #aaa2b8; font-size: 12px; line-height: 1.65; margin: 24px 0; }
+.bots-list-card > a { margin-top: auto; color: var(--bot-accent); font-size: 10px; letter-spacing: .12em; text-decoration: none; text-transform: uppercase; }
+.bots-list-card > a span { display: inline-block; margin-left: 5px; transition: transform .15s ease; }
+.bots-list-card > a:hover span { transform: translateX(4px); }
+.bots-list-note { display: grid; grid-template-columns: 170px 1fr; gap: 34px; margin: 36px 0 80px; padding: 24px; border: 1px solid #6e5e22; background: rgba(245,217,74,.045); }
+.bots-list-note span { color: var(--gold); font-size: 9px; text-transform: uppercase; letter-spacing: .15em; }
+.bots-list-note p { color: #aaa292; font-size: 12px; line-height: 1.65; margin: 0; }
+@media (max-width: 720px) {
+  .bots-list-hero { grid-template-columns: 1fr; min-height: 500px; } .bots-list-hero > p { grid-column: auto; }
+  .bots-list-grid { grid-template-columns: 1fr; } .bots-list-card { min-height: 440px; padding: 24px; }
+  .bots-list-note { grid-template-columns: 1fr; gap: 13px; }
+}
+
+/* TISSUE-0 bot dossier */
+.bots-page { background: #09070f; }
+.bots-wrap { max-width: 1160px; }
+.bots-hero { min-height: 690px; display: grid; grid-template-columns: minmax(0,1.02fr) minmax(390px,.98fr); gap: 58px;
+  align-items: center; border-bottom: 1px solid var(--edge); padding: 72px 0; }
+.bots-kicker, .bots-overline, .bots-index { color: var(--cyan); text-transform: uppercase; letter-spacing: .2em; font-size: 10px; }
+.bots-hero h1 { margin: 26px 0 0; color: var(--gold); font-size: clamp(5rem, 11vw, 8.5rem); line-height: .75;
+  letter-spacing: -.085em; text-shadow: 4px 5px 0 #741f24; }
+.bots-hero h1 span { color: var(--cyan); }
+.bots-deck { max-width: 650px; margin: 42px 0 0; color: #d9d2e4; font-family: Georgia, 'Times New Roman', serif;
+  font-size: clamp(19px, 2.2vw, 25px); line-height: 1.52; }
+.bots-actions { display: flex; gap: 12px; flex-wrap: wrap; margin-top: 34px; }
+.bots-diagram { position: relative; padding: 24px; border: 1px solid var(--edge); background:
+  linear-gradient(rgba(111,224,240,.035) 1px, transparent 1px), linear-gradient(90deg, rgba(111,224,240,.035) 1px, transparent 1px), #0c0912;
+  background-size: 24px 24px; box-shadow: 0 26px 70px rgba(0,0,0,.34); }
+.bots-diagram span, .bots-diagram b, .bots-diagram small { display: block; }
+.bots-diagram span { color: var(--red); font-size: 9px; letter-spacing: .15em; }
+.bots-diagram b { color: var(--text); font-size: 13px; margin-top: 6px; }
+.bots-diagram small { color: var(--dim); font-size: 10px; margin-top: 4px; }
+.bots-diagram__input, .bots-diagram__output { padding: 15px; border: 1px solid var(--edge); background: #14101d; }
+.bots-diagram__output { border-color: #6e5e22; }
+.bots-diagram__arrow { color: var(--cyan); text-align: center; padding: 8px; }
+.bots-diagram__split { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+.bots-diagram__split > div { padding: 15px; border: 1px solid #334753; background: #0b1217; }
+.bots-diagram__tissue { display: grid; grid-template-columns: 142px 1fr; align-items: center; gap: 18px; padding: 16px;
+  border: 1px solid #704045; background: rgba(73,24,31,.18); }
+.bots-diagram__cells { display: grid; grid-template-columns: repeat(6, 1fr); gap: 3px; aspect-ratio: 1; }
+.bots-diagram__cells i { background: var(--cyan); opacity: .28; }
+.bots-diagram__cells i:nth-child(3n) { background: var(--gold); opacity: .62; }
+.bots-diagram__cells i:nth-child(5n) { background: var(--red); opacity: .75; }
+.bots-facts { display: grid; grid-template-columns: repeat(4, 1fr); border-bottom: 1px solid var(--edge); }
+.bots-facts article { padding: 28px 24px; border-right: 1px solid var(--edge); }
+.bots-facts article:first-child { padding-left: 0; } .bots-facts article:last-child { border-right: 0; }
+.bots-facts span, .bots-facts small { display: block; color: var(--dim); font-size: 9px; letter-spacing: .14em; text-transform: uppercase; }
+.bots-facts b { display: block; color: var(--text); font-size: clamp(23px, 3.2vw, 35px); margin: 7px 0 5px; }
+.bots-section { display: grid; grid-template-columns: 145px 1fr; gap: 48px; padding: 86px 0; border-bottom: 1px solid var(--edge); }
+.bots-section > * { min-width: 0; }
+.bots-page--ultra .rs-btn:not(.ghost) { color: #17131f; border-color: var(--gold); background: var(--gold); }
+.bots-page--ultra .bots-training-grid span { color: #ff7168; }
+.bots-page--ultra .bots-equation:focus-visible, .bots-page--ultra .bots-control-flow:focus-visible { outline: 2px solid var(--cyan); outline-offset: 3px; }
+.bots-index { color: var(--red); padding-top: 7px; white-space: nowrap; }
+.bots-overline { margin: 0 0 16px; }
+.bots-section h2 { margin: 0 0 30px; max-width: 820px; color: var(--gold); font-size: clamp(29px, 4.6vw, 54px); line-height: 1.04; letter-spacing: -.045em; }
+.bots-section p { color: #c9c1d5; line-height: 1.75; }
+.bots-columns { display: grid; grid-template-columns: 1fr 1fr; gap: 36px; }
+.bots-columns p { margin: 0; }
+.bots-equation { margin-top: 30px; padding: 22px 24px; border: 1px solid #6e5e22; background: rgba(245,217,74,.045); overflow-x: auto; }
+.bots-equation span, .bots-equation code, .bots-equation small { display: block; }
+.bots-equation span { color: var(--gold); font-size: 9px; letter-spacing: .16em; text-transform: uppercase; margin-bottom: 14px; }
+.bots-equation code { color: #e9dfb7; font-size: 12px; line-height: 1.8; white-space: nowrap; }
+.bots-equation small { max-width: 780px; color: var(--dim); line-height: 1.55; margin-top: 14px; }
+.bots-equation--cyan { border-color: #334753; background: rgba(111,224,240,.035); }
+.bots-equation--cyan span, .bots-equation--cyan code { color: var(--cyan); }
+.bots-tensors { display: grid; grid-template-columns: repeat(3,1fr); border: 1px solid var(--edge); }
+.bots-tensors article { min-height: 180px; padding: 22px; border-right: 1px solid var(--edge); border-bottom: 1px solid var(--edge); }
+.bots-tensors article:nth-child(3n) { border-right: 0; } .bots-tensors article:nth-last-child(-n+3) { border-bottom: 0; }
+.bots-tensors span { color: var(--cyan); font-size: 9px; letter-spacing: .13em; text-transform: uppercase; }
+.bots-tensors b { display: block; color: var(--text); font-size: 22px; margin: 25px 0 10px; }
+.bots-tensors p { color: var(--dim); font-size: 12px; line-height: 1.55; margin: 0; }
+.bots-note { max-width: 850px; border-left: 2px solid var(--red); padding: 3px 0 3px 17px; color: var(--dim) !important; font-size: 13px; margin-top: 24px; }
+.bots-stages { display: grid; grid-template-columns: 1fr 1fr; border: 1px solid var(--edge); }
+.bots-stages article { position: relative; min-height: 230px; padding: 26px; border-right: 1px solid var(--edge); border-bottom: 1px solid var(--edge); }
+.bots-stages article:nth-child(even) { border-right: 0; } .bots-stages article:nth-last-child(-n+2) { border-bottom: 0; }
+.bots-stages i { color: var(--red); font-style: normal; font-size: 10px; letter-spacing: .18em; }
+.bots-stages h3 { margin: 35px 0 12px; color: var(--cyan); font-size: 16px; text-transform: uppercase; letter-spacing: .11em; }
+.bots-stages p { color: #aaa2b8; font-size: 13px; line-height: 1.65; margin: 0; }
+.bots-adapt-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; margin-top: 24px; background: var(--edge); border: 1px solid var(--edge); }
+.bots-adapt-grid article { background: #0d0a14; padding: 24px; }
+.bots-adapt-grid span, .bots-training-grid span { color: var(--red); text-transform: uppercase; letter-spacing: .14em; font-size: 9px; }
+.bots-adapt-grid h3 { color: var(--cyan); margin: 22px 0 9px; text-transform: uppercase; letter-spacing: .08em; font-size: 13px; }
+.bots-adapt-grid p, .bots-training-grid p { color: #aaa2b8; font-size: 12px; line-height: 1.6; margin: 0; }
+.bots-branches { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-bottom: 26px; }
+.bots-branches article { display: grid; grid-template-columns: 48px 1fr; gap: 17px; align-items: center; padding: 19px; border: 1px solid var(--edge); background: var(--panel); }
+.bots-branches i { display: flex; align-items: center; justify-content: center; width: 48px; height: 48px; border: 1px solid #334753; color: var(--cyan); font-style: normal; font-size: 18px; }
+.bots-branches h3 { color: var(--text); margin: 0 0 6px; font-size: 13px; text-transform: uppercase; letter-spacing: .09em; }
+.bots-branches p { margin: 0; color: var(--dim); font-size: 11px; line-height: 1.55; }
+.bots-control-flow { display: flex; align-items: stretch; margin: 28px 0; overflow-x: auto; }
+.bots-control-flow span { display: flex; align-items: center; min-width: 132px; padding: 18px; border: 1px solid var(--edge); color: var(--text); font-size: 11px; line-height: 1.4; text-transform: uppercase; letter-spacing: .08em; }
+.bots-control-flow i { display: flex; align-items: center; padding: 0 9px; color: var(--red); font-style: normal; }
+.bots-training-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.bots-training-grid article { min-height: 170px; padding: 23px; border: 1px solid var(--edge); background: var(--panel); }
+.bots-training-grid p { margin-top: 24px; }
+.bots-gates { margin-top: 24px; padding: 24px; border: 1px solid #2e6040; background: rgba(13,30,22,.35); }
+.bots-gates > span { color: var(--green); font-size: 10px; text-transform: uppercase; letter-spacing: .15em; }
+.bots-gates ul { display: grid; grid-template-columns: 1fr 1fr; gap: 12px 28px; list-style: none; padding: 0; margin: 20px 0 0; }
+.bots-gates li { color: #b9cbbd; font-size: 12px; line-height: 1.5; }
+.bots-gates li::before { content: '✓ '; color: var(--green); }
+.bots-evidence-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; border: 1px solid var(--edge); background: var(--edge); }
+.bots-evidence-grid article { padding: 24px; background: #0d0a14; }
+.bots-evidence-grid span { color: var(--green); font-size: 10px; text-transform: uppercase; letter-spacing: .14em; }
+.bots-evidence-grid article[data-state='open'] span { color: var(--gold); }
+.bots-evidence-grid p { color: #aaa2b8; font-size: 12px; line-height: 1.65; margin: 20px 0 0; }
+.bots-verdict { margin-top: 28px; padding: 28px; border: 1px solid #6e5e22; background: rgba(245,217,74,.05); }
+.bots-verdict b { color: var(--gold); font-size: 15px; }
+.bots-verdict p { max-width: 850px; color: #c6bdad; font-size: 13px; }
+.bots-verdict a { color: var(--cyan); font-size: 11px; text-transform: uppercase; letter-spacing: .1em; text-decoration: none; }
+.bots-code { display: grid; gap: 1px; padding: 18px; background: var(--edge); border: 1px solid var(--edge); }
+.bots-code code { padding: 13px 15px; background: #0b0812; color: #d8d1e1; font-size: 12px; }
+.bots-code code span { display: inline-block; min-width: 78px; color: var(--cyan); }
+.bots-runtime p:last-child { max-width: 870px; margin-top: 28px; }
+.bots-build-grid { display: grid; grid-template-columns: repeat(3,1fr); gap: 12px; margin: 28px 0 24px; }
+.bots-build-grid article { min-width: 0; padding: 22px; border: 1px solid var(--edge); background: var(--panel); }
+.bots-build-grid i { color: var(--red); font-size: 10px; font-style: normal; letter-spacing: .18em; }
+.bots-build-grid h3 { color: var(--cyan); margin: 24px 0 13px; font-size: 12px; letter-spacing: .1em; text-transform: uppercase; }
+.bots-build-grid pre { margin: 0; overflow-x: auto; }
+.bots-build-grid code { color: #d7d0df; font-size: 10px; line-height: 1.7; }
+.bots-protocol { display: grid; grid-template-columns: repeat(3,1fr); border: 1px solid var(--edge); margin-bottom: 24px; }
+.bots-protocol > div { padding: 21px; border-right: 1px solid var(--edge); }
+.bots-protocol > div:last-child { border-right: 0; }
+.bots-protocol span { color: var(--gold); font-size: 9px; letter-spacing: .14em; text-transform: uppercase; }
+.bots-protocol p { color: var(--dim); font-size: 11px; line-height: 1.65; margin: 17px 0 0; }
+.bots-protocol code { color: var(--cyan); }
+@media (max-width: 900px) {
+  .bots-hero { grid-template-columns: 1fr; } .bots-diagram { max-width: 620px; }
+  .bots-section { grid-template-columns: 1fr; gap: 20px; padding: 64px 0; }
+  .bots-tensors { grid-template-columns: 1fr 1fr; } .bots-tensors article:nth-child(3n) { border-right: 1px solid var(--edge); }
+  .bots-tensors article:nth-child(even) { border-right: 0; } .bots-tensors article:nth-last-child(-n+3) { border-bottom: 1px solid var(--edge); }
+  .bots-tensors article:nth-last-child(-n+2) { border-bottom: 0; }
+  .bots-build-grid { grid-template-columns: 1fr; }
+}
+@media (max-width: 620px) {
+  .bots-hero { min-height: 0; padding: 54px 0; } .bots-hero h1 { font-size: 20vw; } .bots-deck { font-size: 18px; }
+  .bots-diagram { padding: 14px; } .bots-diagram__tissue { grid-template-columns: 92px 1fr; } .bots-diagram__split { grid-template-columns: 1fr; }
+  .bots-facts { grid-template-columns: 1fr 1fr; } .bots-facts article:nth-child(2) { border-right: 0; }
+  .bots-facts article:nth-child(-n+2) { border-bottom: 1px solid var(--edge); } .bots-facts article:nth-child(3) { padding-left: 0; }
+  .bots-columns, .bots-stages, .bots-adapt-grid, .bots-branches, .bots-training-grid, .bots-evidence-grid { grid-template-columns: 1fr; }
+  .bots-stages article, .bots-stages article:nth-child(even) { border-right: 0; border-bottom: 1px solid var(--edge); }
+  .bots-stages article:last-child { border-bottom: 0; }
+  .bots-tensors { grid-template-columns: 1fr; } .bots-tensors article, .bots-tensors article:nth-child(even), .bots-tensors article:nth-child(3n), .bots-tensors article:nth-last-child(-n+2) { border-right: 0; border-bottom: 1px solid var(--edge); }
+  .bots-tensors article:last-child { border-bottom: 0; } .bots-equation code { min-width: 650px; }
+  .bots-gates ul { grid-template-columns: 1fr; } .bots-control-flow { padding-bottom: 8px; }
+  .bots-protocol { grid-template-columns: 1fr; } .bots-protocol > div { border-right: 0; border-bottom: 1px solid var(--edge); }
+  .bots-protocol > div:last-child { border-bottom: 0; }
+}
 
 /* replay viewer */
 .rs-replay { background: var(--panel); border: 1px solid var(--edge); border-radius: 14px; overflow: hidden; box-shadow: var(--glow); }


### PR DESCRIPTION
## Summary
- restore the full TISSUE-0 and Ultra technical dossier pages
- feature both dossiers on `/bots/list` while retaining the live data-driven bot ladder
- keep bot policies, training systems, models and deployment services outside this repository
- update the TISSUE protocol example for the current opponent-pool contract

## Verification
- Next.js production build and TypeScript pass
- `/bots/list`, `/bots/list/tissue`, and `/bots/list/ultra` all generated
- browser-verified all three pages with no Next.js error overlay
- Ultra page includes the corrected paired-seat evaluation audit