### PR TITLE
Add Google Analytics tag

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,8 +1,10 @@
 import './globals.css';
 import type { ReactNode } from 'react';
 import type { Metadata, Viewport } from 'next';
+import { GoogleAnalytics } from '@next/third-parties/google';
 
 const DESC = 'An arcade fighting game you play entirely over SSH — a live ranked ladder, watchable replays, character stats, hand-drawn pixel sprites and a bot API. No install. Just connect and fight.';
+const GOOGLE_ANALYTICS_ID = 'G-H6D2K44Q8T';
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://sshfighter.com'),
@@ -40,6 +42,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body>{children}</body>
+      <GoogleAnalytics gaId={GOOGLE_ANALYTICS_ID} />
     </html>
   );
 }

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
     "start": "next start -p 3130"
   },
   "dependencies": {
+    "@next/third-parties": "16.3.1",
     "better-sqlite3": "^13.0.3",
     "next": "16.3.1",
     "react": "^19.2.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@next/third-parties':
+        specifier: 16.3.1
+        version: 16.3.1(next@16.3.1(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       better-sqlite3:
         specifier: ^13.0.3
         version: 13.0.3
@@ -421,6 +424,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@next/third-parties@16.3.1':
+    resolution: {integrity: sha512-OyIUIohaQ8AkD/8Ew0yPTaxcoOwobIgBjvNnhajgJ2IWPuSjFHfKYAFmFjYmL5Jwrf2qJDWubadhPqPbFhrDNg==}
+    peerDependencies:
+      next: ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+
   '@swc/helpers@0.5.23':
     resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
@@ -549,6 +558,9 @@ packages:
         optional: true
       babel-plugin-macros:
         optional: true
+
+  third-party-capital@1.0.20:
+    resolution: {integrity: sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -783,6 +795,12 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.3.1':
     optional: true
 
+  '@next/third-parties@16.3.1(next@16.3.1(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      next: 16.3.1(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
+      third-party-capital: 1.0.20
+
   '@swc/helpers@0.5.23':
     dependencies:
       tslib: 2.8.1
@@ -936,6 +954,8 @@ snapshots:
     dependencies:
       client-only: 0.0.1
       react: 19.2.8
+
+  third-party-capital@1.0.20: {}
 
   tslib@2.8.1: {}
 


### PR DESCRIPTION
## Summary
- load Google Analytics globally with measurement ID `G-H6D2K44Q8T`
- use Next.js `GoogleAnalytics` integration to emit the supplied gtag loader and initialization after hydration
- pin `@next/third-parties` to the installed Next.js version

## Verification
- Next.js production build and TypeScript pass
- generated HTML contains `https://www.googletagmanager.com/gtag/js?id=G-H6D2K44Q8T`
- generated HTML contains the supplied measurement ID on static routes