### PR TITLE
Polish the arcade design and complete page metadata

### DIFF
--- a/web/app/bots/list/page.tsx
+++ b/web/app/bots/list/page.tsx
@@ -2,12 +2,14 @@ import Link from 'next/link';
 import { SiteNav, Footer, CharChip, PlayerTypeBadge } from '@/components/ui';
 import { topPlayers, onlineNow, summary } from '@/lib/ringside';
 import { winRate } from '@/lib/format';
+import { pageMetadata } from '@/lib/metadata';
 
 export const dynamic = 'force-dynamic';
-export const metadata = {
+export const metadata = pageMetadata({
   title: 'Bot roster',
   description: 'Technical bot dossiers and ranked automated players competing in the SSH Fighter Open League.',
-};
+  path: '/bots/list',
+});
 
 const dossiers = [
   {

--- a/web/app/bots/list/tissue/page.tsx
+++ b/web/app/bots/list/tissue/page.tsx
@@ -1,11 +1,12 @@
 import Link from 'next/link';
 import { Footer, SiteNav } from '@/components/ui';
+import { pageMetadata } from '@/lib/metadata';
 
-export const metadata = {
+export const metadata = pageMetadata({
   title: 'TISSUE-0 bot',
   description: 'A technical explanation of TISSUE-0, the morphogenetic immune control policy fighting live on SSH Fighter.',
-  alternates: { canonical: '/bots/list/tissue' },
-};
+  path: '/bots/list/tissue',
+});
 
 const runtimeState = [
   ['Fine tissue', '12 × 12 × 64', 'Fast electrical state shared by local cell updates'],

--- a/web/app/bots/list/ultra/page.tsx
+++ b/web/app/bots/list/ultra/page.tsx
@@ -1,11 +1,12 @@
 import Link from 'next/link';
 import { Footer, SiteNav } from '@/components/ui';
+import { pageMetadata } from '@/lib/metadata';
 
-export const metadata = {
+export const metadata = pageMetadata({
   title: 'Ultra bot',
   description: 'A technical dossier for Ultra, the recurrent self-play policy fighting live on SSH Fighter.',
-  alternates: { canonical: '/bots/list/ultra' },
-};
+  path: '/bots/list/ultra',
+});
 
 const observationGroups = [
   ['Geometry', '0–5', 'Facing-canonical relative position and velocity, horizontal distance and vertical separation.'],

--- a/web/app/bots/page.tsx
+++ b/web/app/bots/page.tsx
@@ -1,9 +1,14 @@
 import Link from 'next/link';
 import { SiteNav, Footer } from '@/components/ui';
 import { onlineNow } from '@/lib/ringside';
+import { pageMetadata } from '@/lib/metadata';
 
 export const dynamic = 'force-dynamic';
-export const metadata = { title: 'Bot API', description: 'Register over SSH and let an agent play the ranked ladder.' };
+export const metadata = pageMetadata({
+  title: 'Build a bot',
+  description: 'Register a bot over SSH, connect to the live fighter protocol, and compete on the SSH Fighter Open League ladder.',
+  path: '/bots',
+});
 
 const GH = 'https://github.com/thomasdavis/sshfighter.com/blob/main/examples/bot.mjs';
 

--- a/web/app/characters/page.tsx
+++ b/web/app/characters/page.tsx
@@ -1,9 +1,14 @@
 import { SiteNav, Footer, CharChip, Bars } from '@/components/ui';
 import { characterStats, matchupGrid, onlineNow } from '@/lib/ringside';
 import { charColor, rosterNames } from '@/lib/chars';
+import { pageMetadata } from '@/lib/metadata';
 
 export const dynamic = 'force-dynamic';
-export const metadata = { title: 'Character stats', description: 'Pick rates, win rates and the matchup grid.' };
+export const metadata = pageMetadata({
+  title: 'Character stats',
+  description: 'Explore SSH Fighter character pick rates, ranked win rates, and head-to-head matchup data.',
+  path: '/characters',
+});
 
 function winColor(pct: number): string {
   // red (low) → amber (even) → green (high)

--- a/web/app/chat/page.tsx
+++ b/web/app/chat/page.tsx
@@ -1,14 +1,16 @@
 import Link from 'next/link';
+import { pageMetadata } from '@/lib/metadata';
 import { SiteNav, Footer } from '@/components/ui';
 import { chatMessages } from '@/lib/ringside';
 import { getLive } from '@/lib/live';
 import { LoungeChat } from '../LoungeChat';
 
 export const dynamic = 'force-dynamic';
-export const metadata = {
+export const metadata = pageMetadata({
   title: 'Fight Lounge',
   description: 'The live Fight Lounge chat — where SSH Fighter players and bots talk between matches.',
-};
+  path: '/chat',
+});
 
 export default async function ChatPage() {
   const live = await getLive();
@@ -33,10 +35,10 @@ export default async function ChatPage() {
                 so people know who they&rsquo;re talking to.</p>
               <div className="rs-cmd sm"><span className="p">$</span><code>ssh <b>sshfighter.com</b></code><span className="hint">↵ open the lounge</span></div>
               <ul className="rs-lounge-side__list" style={{ marginTop: 18 }}>
-                <li><span>◈</span> Live roster of who&rsquo;s around</li>
-                <li><span>⚔</span> Challenge anyone straight to a match</li>
-                <li><span>⌁</span> Agents chat here too <em>— it&rsquo;s on the bot API</em></li>
-                <li><span>⏱</span> 140 chars per line, oldest at top</li>
+                <li>Live roster of who&rsquo;s around</li>
+                <li>Challenge anyone straight to a match</li>
+                <li>Agents chat here too <em>— it&rsquo;s on the bot API</em></li>
+                <li>140 chars per line, oldest at top</li>
               </ul>
               <div style={{ marginTop: 'auto', paddingTop: 18 }}>
                 <Link className="rs-btn ghost" href="/bots">Build a bot that chats →</Link>

--- a/web/app/fighters/[id]/page.tsx
+++ b/web/app/fighters/[id]/page.tsx
@@ -1,14 +1,17 @@
-import type { CSSProperties } from 'react';
+import { cache, type CSSProperties } from 'react';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { fighterSlugs, getFighterProfile } from '@/lib/fighters';
 import { listPoses, spriteMtime } from '@/lib/sprites';
 import AnimatedSprite from './AnimatedSprite';
+import { pageMetadata } from '@/lib/metadata';
 
 interface PageProps {
   params: Promise<{ id: string }>;
 }
+
+const getCachedFighterProfile = cache(getFighterProfile);
 
 export const dynamic = 'force-dynamic';
 
@@ -18,17 +21,19 @@ export function generateStaticParams() {
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { id } = await params;
-  const profile = getFighterProfile(id);
-  if (!profile) return { title: 'Fighter not found — SSH Fighter' };
-  return {
-    title: `${profile.character.name} — ${profile.character.tagline} | SSH Fighter`,
+  const profile = getCachedFighterProfile(id);
+  if (!profile) return { title: 'Fighter not found', robots: { index: false, follow: false } };
+  return pageMetadata({
+    title: `${profile.character.name} — ${profile.character.tagline}`,
     description: `${profile.character.name} fighter guide: background story, animated sprites, special-move inputs, damage, frame data, and tactics.`,
-  };
+    path: `/fighters/${id}`,
+    imageAlt: `${profile.character.name}, a playable pixel-art fighter in SSH Fighter`,
+  });
 }
 
 export default async function FighterPage({ params }: PageProps) {
   const { id } = await params;
-  const profile = getFighterProfile(id);
+  const profile = getCachedFighterProfile(id);
   if (!profile) notFound();
   const { character } = profile;
   const style = { '--fighter-accent': profile.accent } as CSSProperties;

--- a/web/app/fighters/page.tsx
+++ b/web/app/fighters/page.tsx
@@ -3,9 +3,14 @@ import { SiteNav, Footer } from '@/components/ui';
 import { SpriteLoop } from '@/components/SpriteLoop';
 import { rosterCards } from '@/lib/chars';
 import { characterStats, onlineNow } from '@/lib/ringside';
+import { pageMetadata } from '@/lib/metadata';
 
 export const dynamic = 'force-dynamic';
-export const metadata = { title: 'Fighters', description: 'The roster. Pick your fighter.' };
+export const metadata = pageMetadata({
+  title: 'Fighters',
+  description: 'Meet every hand-drawn SSH Fighter character, compare playstyles, and choose your main.',
+  path: '/fighters',
+});
 
 const DIFF: Record<string, { pips: number; cls: string }> = {
   Beginner: { pips: 1, cls: 'beg' }, Intermediate: { pips: 2, cls: 'int' }, Advanced: { pips: 3, cls: 'adv' },
@@ -19,7 +24,7 @@ export default function FightersPage() {
     <div className="rs">
       <SiteNav active="/fighters" online={onlineNow()} />
       <main className="rs-wrap rs-wrap--wide">
-        <div className="rs-ph" style={{ textAlign: 'center' }}>
+        <div className="rs-ph rs-ph--center">
           <p className="rs-hero__eyebrow" style={{ margin: '0 0 8px' }}>{cards.length} fighters · one terminal</p>
           <h1 style={{ fontSize: 'clamp(2.2rem,6vw,4rem)' }}>Select your fighter</h1>
           <p>Hand-drawn pixel warriors. Learn one, climb the ladder — or point a bot at them.</p>

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1,8 +1,8 @@
 :root {
-  --bg: #17131f;
-  --bg2: #211a2e;
-  --tile: #0e0b16;
-  --line: #3a2f52;
+  --bg: #15101e;
+  --bg2: #21182f;
+  --tile: #0c0913;
+  --line: #40325c;
   --gold: #f5d94a;
   --cyan: #6fe0f0;
   --text: #e9e4f2;
@@ -11,9 +11,15 @@
   --green: #64d878;
 }
 * { box-sizing: border-box; }
+html { scrollbar-color: var(--line) var(--tile); scrollbar-width: thin; }
 html, body { margin: 0; padding: 0; background: var(--bg); color: var(--text);
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; }
-a { color: var(--cyan); }
+a { color: var(--cyan); text-underline-offset: .2em; text-decoration-thickness: 1px; }
+::selection { color: var(--ink); background: var(--gold); }
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-track { background: var(--tile); }
+::-webkit-scrollbar-thumb { background: var(--line); border: 2px solid var(--tile); }
+::-webkit-scrollbar-thumb:hover { background: var(--dim); }
 a:focus-visible, button:focus-visible, input:focus-visible { outline: 2px solid var(--gold); outline-offset: 3px; }
 
 .wrap { max-width: 1200px; margin: 0 auto; padding: 28px 20px 80px; }
@@ -199,27 +205,44 @@ button.regen:disabled { opacity: 0.4; cursor: not-allowed; }
    Ringside site — retro arcade UI (nav, hero, stats, tables, charts, matches)
    Extends the tokens above. Prefixed .rs- to avoid clashing with the gallery.
    ============================================================================ */
-:root { --ink: #0b0812; --panel: #1b1526; --panel2: #241c33; --edge: #3a2f52;
-  --scan: rgba(255,255,255,.02); --glow: 0 0 0 1px var(--edge), 0 0 22px -8px #000; }
+:root { --ink: #09060f; --panel: #1b1426; --panel2: #261c36; --edge: #40325c;
+  --scan: rgba(255,255,255,.018); --glow: 0 18px 44px -32px rgba(0,0,0,.96); }
 
-.rs { --w: 1180px; min-height: 100vh; background:
-  radial-gradient(1200px 620px at 50% -10%, #241b34 0%, transparent 70%), var(--bg); }
+.rs { --w: 1180px; position: relative; isolation: isolate; min-height: 100vh; overflow: clip; background:
+  radial-gradient(900px 540px at 8% 8%, rgba(111,224,240,.07), transparent 68%),
+  radial-gradient(980px 680px at 96% 18%, rgba(224,72,63,.08), transparent 68%),
+  radial-gradient(1200px 620px at 50% -10%, #271c38 0%, transparent 70%), var(--bg); }
+.rs::before { content: ''; position: fixed; z-index: 80; inset: 0; pointer-events: none; opacity: .5;
+  background: repeating-linear-gradient(0deg, transparent 0 3px, var(--scan) 3px 4px); }
 .rs-wrap { max-width: var(--w); margin: 0 auto; padding: 0 22px; }
 .rs-wrap--wide { max-width: 1340px; }
 
 /* top nav */
-.rs-nav { position: sticky; top: 0; z-index: 40; background: rgba(11,8,18,.82);
-  backdrop-filter: blur(8px); border-bottom: 1px solid var(--edge); }
-.rs-nav__in { max-width: var(--w); margin: 0 auto; padding: 11px 22px; display: flex; align-items: center; gap: 20px; }
+.rs-nav { position: sticky; top: 0; z-index: 40; background: rgba(9,6,15,.9);
+  backdrop-filter: blur(12px) saturate(1.18); border-bottom: 1px solid var(--edge); box-shadow: 0 12px 34px -28px #000; }
+.rs-nav::after { content: ''; position: absolute; left: 0; right: 0; bottom: -1px; height: 1px;
+  background: linear-gradient(90deg, transparent 5%, var(--red) 24%, var(--gold) 50%, var(--cyan) 76%, transparent 95%); opacity: .72; }
+.rs-nav__signal { height: 22px; overflow: hidden; border-bottom: 1px solid #251b34; background: #0b0812; }
+.rs-nav__signal > div { min-height: 22px; max-width: var(--w); margin: 0 auto; padding: 0 22px; display: flex; align-items: center;
+  justify-content: center; gap: clamp(22px, 5vw, 72px); color: #887d9c; font-size: 8px; letter-spacing: .19em; text-transform: uppercase; }
+.rs-nav__signal span { display: inline-flex; align-items: center; gap: 8px; white-space: nowrap; }
+.rs-nav__signal span::before { content: ''; width: 5px; height: 5px; background: var(--cyan); box-shadow: 1px 1px 0 rgba(111,224,240,.2); }
+.rs-nav__signal span:nth-child(2)::before { background: var(--green); }
+.rs-nav__signal span:nth-child(3)::before { background: var(--gold); }
+.rs-nav__signal span:nth-child(4)::before { background: var(--red); }
+.rs-nav__in { max-width: var(--w); margin: 0 auto; padding: 10px 22px; display: flex; align-items: center; gap: 18px; }
 .rs-brand { display: flex; align-items: center; gap: 9px; color: var(--gold); text-decoration: none;
   font-weight: 800; letter-spacing: 1.5px; font-size: 14px; text-shadow: 1.5px 1.5px 0 #7a1f1a; white-space: nowrap; }
 .rs-brand b { width: 12px; height: 12px; background: var(--red); box-shadow: 3px 0 var(--gold), 0 3px var(--cyan), 3px 3px #fff;
   image-rendering: pixelated; }
+.rs-brand__fighter { width: 28px; height: 34px; margin: -8px 0 -8px 1px; display: flex; align-items: flex-end; justify-content: center; overflow: hidden; }
+.rs-brand__fighter img { display: block; max-width: 100%; max-height: 100%; image-rendering: pixelated; filter: drop-shadow(0 5px 5px rgba(0,0,0,.65)); }
 .rs-navlinks { display: flex; gap: 3px; flex-wrap: wrap; margin-left: 6px; }
-.rs-navlinks a { color: var(--dim); text-decoration: none; font-size: 11.5px; letter-spacing: .12em;
-  text-transform: uppercase; padding: 7px 11px; border-radius: 6px; }
+.rs-navlinks a { position: relative; color: var(--dim); text-decoration: none; font-size: 11px; letter-spacing: .12em;
+  text-transform: uppercase; padding: 7px 9px; border-radius: 5px; }
 .rs-navlinks a:hover { color: var(--text); background: var(--panel2); }
 .rs-navlinks a[data-active="1"] { color: var(--gold); background: var(--panel); }
+.rs-navlinks a[data-active="1"]::after { content: ''; position: absolute; left: 9px; right: 9px; bottom: 2px; height: 1px; background: var(--gold); }
 .rs-nav__live { margin-left: auto; display: flex; align-items: center; gap: 8px; color: var(--text);
   font-size: 12px; border: 1px solid var(--edge); border-radius: 999px; padding: 6px 13px; white-space: nowrap; }
 .rs-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--green); box-shadow: 0 0 10px var(--green);
@@ -229,8 +252,9 @@ button.regen:disabled { opacity: 0.4; cursor: not-allowed; }
 /* hero */
 .rs-hero { display: grid; grid-template-columns: minmax(0,1fr) minmax(340px,1fr); gap: 34px;
   align-items: center; padding: 54px 0 38px; }
-.rs-hero__theater { width: 100%; min-width: 0; }
-.rs-hero__theater .rs-theater { max-width: none; margin: 0; }
+.rs-hero__theater { position: relative; width: 100%; min-width: 0; aspect-ratio: 3 / 2; }
+.rs-hero__theater .rs-theater { position: absolute; z-index: 2; inset: 0; max-width: none; margin: 0; }
+.rs-hero__fallback { position: absolute; z-index: 1; inset: 0; width: 100%; height: 100%; }
 .rs-hero__eyebrow { color: var(--cyan); font-size: 12px; letter-spacing: .28em; text-transform: uppercase; margin: 0 0 14px; }
 .rs-hero h1 { margin: 0; color: var(--gold); font-size: clamp(2.6rem, 6vw, 4.6rem); line-height: .9;
   letter-spacing: -.02em; text-transform: uppercase; text-shadow: 3px 3px 0 #7a1f1a, 6px 6px 0 rgba(0,0,0,.35); }
@@ -238,9 +262,13 @@ button.regen:disabled { opacity: 0.4; cursor: not-allowed; }
 .rs-byline { margin: -14px 0 26px; color: var(--dim); font-size: 12px; letter-spacing: .08em; text-transform: uppercase; }
 .rs-byline a { color: var(--cyan); text-decoration: none; }
 .rs-byline a:hover { text-decoration: underline; }
+.rs-signal-tags { display: flex; flex-wrap: wrap; gap: 8px; margin: -10px 0 22px; }
+.rs-signal-tags span { padding: 5px 9px; border: 1px solid #4b3b69; border-radius: 999px; color: #b9afc8;
+  background: rgba(27,20,38,.72); font-size: 9px; letter-spacing: .13em; text-transform: uppercase; }
 .rs-cta { display: flex; flex-direction: column; gap: 12px; }
-.rs-cmd { display: flex; align-items: center; gap: 12px; background: var(--ink); border: 1px solid var(--edge);
-  border-radius: 10px; padding: 15px 18px; box-shadow: var(--glow); }
+.rs-cmd { position: relative; display: flex; align-items: center; gap: 12px; background: linear-gradient(180deg, #100b19, var(--ink)); border: 1px solid var(--edge);
+  border-radius: 10px; padding: 15px 18px; box-shadow: var(--glow); overflow: hidden; }
+.rs-cmd::before { content: ''; position: absolute; top: 0; left: 0; bottom: 0; width: 2px; background: var(--green); box-shadow: 0 0 12px rgba(100,216,120,.42); }
 .rs-cmd .p { color: var(--green); }
 .rs-cmd code { color: var(--text); font-size: 16px; letter-spacing: .5px; }
 .rs-cmd code b { color: var(--cyan); font-weight: 400; }
@@ -254,10 +282,16 @@ button.regen:disabled { opacity: 0.4; cursor: not-allowed; }
 .rs-hero__art img.r { right: 4%; transform: scaleX(-1); }
 .rs-hero__art .vs { position: absolute; top: 50%; left: 50%; transform: translate(-50%,-50%);
   color: var(--gold); font-size: 34px; font-weight: 800; letter-spacing: 2px; text-shadow: 2px 2px 0 var(--red); }
+.rs-hero__theater > .rs-hero__fallback { height: 100%; }
 
 /* stat strip */
 .rs-stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px,1fr)); gap: 12px; margin: 8px 0 40px; }
-.rs-stat { background: var(--panel); border: 1px solid var(--edge); border-radius: 12px; padding: 16px 18px; }
+.rs-stat { position: relative; overflow: hidden; background: linear-gradient(145deg, #1e172a, #171120); border: 1px solid var(--edge); border-radius: 12px; padding: 18px;
+  transition: transform .18s cubic-bezier(.16,1,.3,1), border-color .18s ease, background .18s ease; }
+.rs-stat::before { content: ''; position: absolute; left: 0; top: 0; width: 38%; height: 2px; background: var(--cyan); }
+.rs-stat:nth-child(2n)::before { background: var(--red); }
+.rs-stat:nth-child(3n)::before { background: var(--gold); }
+.rs-stat:hover { transform: translateY(-2px); border-color: #5a477e; background: linear-gradient(145deg, #241b32, #181121); }
 .rs-stat b { display: block; color: var(--text); font-size: 30px; letter-spacing: -.5px; font-variant-numeric: tabular-nums; }
 .rs-stat span { color: var(--dim); font-size: 11px; text-transform: uppercase; letter-spacing: .14em; }
 .rs-stat.hl b { color: var(--gold); }
@@ -267,6 +301,8 @@ button.regen:disabled { opacity: 0.4; cursor: not-allowed; }
 .rs-section__head { display: flex; align-items: baseline; justify-content: space-between; gap: 18px;
   margin: 0 0 16px; border-bottom: 1px solid var(--edge); padding-bottom: 9px; }
 .rs-section__head h2 { margin: 0; color: var(--gold); font-size: 15px; letter-spacing: .12em; text-transform: uppercase; }
+.rs-section__head h2::before { content: ''; display: inline-block; width: 7px; height: 7px; margin: 0 10px 1px 0; background: var(--gold);
+  box-shadow: 2px 2px 0 rgba(224,72,63,.72); }
 .rs-section__head a { color: var(--cyan); text-decoration: none; font-size: 11px; letter-spacing: .1em; text-transform: uppercase; }
 .rs-section__head a:hover { color: var(--gold); }
 .rs-grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 22px; }
@@ -292,9 +328,10 @@ button.regen:disabled { opacity: 0.4; cursor: not-allowed; }
 .rs-chip--sm i { width: 7px; height: 7px; }
 
 /* match card */
-.rs-match { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 12px;
-  background: var(--panel); border: 1px solid var(--edge); border-radius: 10px; padding: 13px 16px; text-decoration: none; }
-.rs-match:hover { border-color: var(--gold); }
+.rs-match { position: relative; display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 12px;
+  background: linear-gradient(145deg, var(--panel), #17101f); border: 1px solid var(--edge); border-radius: 10px; padding: 13px 16px; text-decoration: none;
+  transition: transform .18s cubic-bezier(.16,1,.3,1), border-color .18s ease, box-shadow .18s ease; }
+.rs-match:hover { transform: translateY(-2px); border-color: var(--gold); box-shadow: 0 16px 28px -24px rgba(245,217,74,.66); }
 .rs-match .side { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
 .rs-match .side.b { text-align: right; align-items: flex-end; }
 .rs-match .side .nm { color: var(--text); font-size: 14px; font-weight: 700; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
@@ -331,17 +368,31 @@ button.regen:disabled { opacity: 0.4; cursor: not-allowed; }
   border-radius: 14px; padding: 26px 28px; box-shadow: var(--glow); }
 .rs-callout h3 { margin: 0 0 8px; color: var(--gold); font-size: 18px; letter-spacing: .04em; }
 .rs-callout p { margin: 0 0 14px; color: #cfc7dd; line-height: 1.6; }
-.rs-btn { display: inline-flex; align-items: center; gap: 8px; background: var(--red); color: #fff; text-decoration: none;
-  padding: 10px 16px; border-radius: 8px; font-size: 12px; letter-spacing: .08em; text-transform: uppercase; font-weight: 700; }
-.rs-btn:hover { filter: brightness(1.12); }
+.rs-btn { display: inline-flex; align-items: center; gap: 8px; background: linear-gradient(180deg, #ed554c, var(--red)); color: #fff; text-decoration: none;
+  padding: 10px 16px; border: 1px solid #f26a62; border-radius: 7px; box-shadow: 0 12px 24px -20px rgba(224,72,63,.9); font-size: 12px; letter-spacing: .08em; text-transform: uppercase; font-weight: 700;
+  transition: transform .16s cubic-bezier(.16,1,.3,1), filter .16s ease, box-shadow .16s ease; }
+.rs-btn:hover { transform: translateY(-2px); filter: brightness(1.08); box-shadow: 0 18px 30px -20px rgba(224,72,63,.95); }
 .rs-btn.ghost { background: transparent; color: var(--cyan); border: 1px solid var(--edge); }
 .rs-btn.ghost:hover { border-color: var(--cyan); color: var(--gold); filter: none; }
 
 /* footer */
-.rs-footer { border-top: 1px solid var(--edge); margin-top: 50px; padding: 26px 0 60px; color: var(--dim); font-size: 12px; }
+.rs-footer { border-top: 1px solid var(--edge); margin-top: 64px; padding: 0 0 54px; color: var(--dim); font-size: 12px; background: rgba(9,6,15,.5); }
 .rs-footer a { color: var(--cyan); text-decoration: none; }
 .rs-footer .row { display: flex; gap: 22px; flex-wrap: wrap; align-items: center; }
 .rs-footer__by { color: #bdb4ca; }
+.rs-footer__arena { position: relative; min-height: 154px; margin: 0 0 28px; display: grid; grid-template-columns: 180px 1fr 180px; align-items: end;
+  overflow: hidden; border-inline: 1px solid var(--edge); border-bottom: 1px solid var(--edge); background:
+  linear-gradient(180deg, rgba(9,6,15,.18), rgba(9,6,15,.82)), url('/api/stage/neon') center 63% / cover no-repeat; }
+.rs-footer__arena::after { content: ''; position: absolute; inset: 0; pointer-events: none; background:
+  linear-gradient(90deg, rgba(9,6,15,.74), transparent 30%, transparent 70%, rgba(9,6,15,.74)),
+  repeating-linear-gradient(0deg, transparent 0 3px, rgba(255,255,255,.026) 3px 4px); }
+.rs-footer__fighter { position: relative; z-index: 1; height: 142px; display: flex; align-items: flex-end; justify-content: center; }
+.rs-footer__fighter img { max-height: 138px; max-width: 100%; image-rendering: pixelated; filter: drop-shadow(0 10px 10px rgba(0,0,0,.72)); }
+.rs-footer__fighter.b { transform: scaleX(-1); }
+.rs-footer__challenge { position: relative; z-index: 2; align-self: center; display: flex; flex-direction: column; align-items: center; text-align: center; text-shadow: 0 3px 12px #000; }
+.rs-footer__challenge small { color: var(--gold); font-size: 9px; letter-spacing: .18em; }
+.rs-footer__challenge strong { margin-top: 9px; padding: 9px 14px; color: var(--cyan); background: rgba(9,6,15,.84); border: 1px solid #4b3b69;
+  border-radius: 6px; font-size: clamp(14px, 2.3vw, 20px); font-weight: 500; }
 
 /* mini sprite frame */
 .rs-face { width: 100%; aspect-ratio: 1; background: repeating-conic-gradient(#160f22 0 25%, #1d1530 0 50%) 0/16px 16px;
@@ -349,16 +400,67 @@ button.regen:disabled { opacity: 0.4; cursor: not-allowed; }
 .rs-face img { max-height: 92%; max-width: 96%; image-rendering: pixelated; }
 
 /* page title */
-.rs-ph { padding: 34px 0 8px; }
-.rs-ph h1 { margin: 0; color: var(--gold); font-size: clamp(2rem,4.5vw,3rem); letter-spacing: -.01em; text-transform: uppercase;
+.rs-ph { position: relative; min-height: 164px; margin: 0 0 28px; padding: 44px 176px 32px 0; display: flex; flex-direction: column; justify-content: center;
+  overflow: hidden; border-bottom: 1px solid var(--edge); }
+.rs-ph::before { content: ''; position: absolute; inset: 0; pointer-events: none; background:
+  radial-gradient(260px 150px at 92% 50%, rgba(111,224,240,.12), transparent 70%),
+  linear-gradient(90deg, transparent 0 58%, rgba(64,50,92,.34) 58% 58.2%, transparent 58.2% 100%); }
+.rs-ph::after { content: ''; position: absolute; right: 24px; bottom: -10px; width: 132px; height: 150px; opacity: .82;
+  background: url('/api/sprite/CHONG/idle_1') center bottom / contain no-repeat; image-rendering: pixelated; filter: drop-shadow(0 10px 12px rgba(0,0,0,.78)); }
+.rs-ph > * { position: relative; z-index: 1; }
+.rs-ph h1 { margin: 0; max-width: 18ch; color: var(--gold); font-size: clamp(2rem,4.5vw,3.4rem); letter-spacing: -.02em; line-height: .96; text-wrap: balance; text-transform: uppercase;
   text-shadow: 2px 2px 0 #7a1f1a; }
-.rs-ph p { margin: 8px 0 0; color: var(--dim); font-size: 13px; }
+.rs-ph p { max-width: 72ch; margin: 11px 0 0; color: #b8aec8; font-size: 13px; line-height: 1.55; }
+.rs-ph--center { padding-left: 176px; text-align: center; align-items: center; }
+.rs-ph--center::after { right: max(18px, calc(50% - 390px)); }
 .rs-empty { color: var(--dim); text-align: center; padding: 40px; border: 1px dashed var(--edge); border-radius: 12px; }
 
 @media (max-width: 860px) {
   .rs-hero { grid-template-columns: 1fr; } .rs-hero__art { height: 240px; order: -1; }
   .rs-grid2, .rs-grid3 { grid-template-columns: 1fr; }
   .rs-nav__live { display: none; }
+  .rs-nav__signal { display: none; }
+  .rs-brand__fighter { display: none; }
+  .rs-nav__in { gap: 9px; padding-block: 9px; }
+  .rs-navlinks { margin-left: 0; }
+  .rs-navlinks a { padding-inline: 7px; font-size: 10px; }
+  .rs-footer__arena { grid-template-columns: 132px 1fr 132px; }
+}
+
+@media (max-width: 620px) {
+  .rs-wrap { padding-inline: 12px; }
+  .rs-brand { font-size: 10px; letter-spacing: 1px; gap: 7px; }
+  .rs-brand b { width: 9px; height: 9px; }
+  .rs-nav__in { align-items: flex-start; padding-inline: 12px; }
+  .rs-navlinks { justify-content: flex-end; }
+  .rs-navlinks a { font-size: 8.5px; padding: 4px 5px; }
+  .rs-ph, .rs-ph--center { min-height: 0; padding: 34px 0 24px; text-align: left; align-items: flex-start; }
+  .rs-ph::after { display: none; }
+  .rs-ph h1 { max-width: none; }
+  .rs-footer__arena { min-height: 132px; grid-template-columns: 88px 1fr 88px; }
+  .rs-footer__fighter { height: 122px; }
+  .rs-footer__fighter img { max-height: 116px; }
+  .rs-footer__challenge small { display: none; }
+  .rs-footer__challenge strong { padding: 8px; font-size: 11px; }
+}
+
+/* route recovery */
+.rs-404 { min-height: 66vh; display: grid; grid-template-columns: minmax(150px, .7fr) minmax(280px, 1.6fr) minmax(150px, .7fr);
+  align-items: end; overflow: hidden; border-bottom: 1px solid var(--edge); background:
+  radial-gradient(560px 300px at 50% 62%, rgba(224,72,63,.13), transparent 72%); }
+.rs-404__copy { align-self: center; padding: 70px 18px; text-align: center; }
+.rs-404__copy > span { color: var(--red); font-size: 10px; font-weight: 800; letter-spacing: .2em; }
+.rs-404__copy h1 { max-width: 11ch; margin: 16px auto 18px; color: var(--gold); font-size: clamp(3rem, 7vw, 5.8rem); line-height: .86;
+  letter-spacing: -.03em; text-transform: uppercase; text-wrap: balance; text-shadow: 3px 3px 0 #741f24; }
+.rs-404__copy p { max-width: 52ch; margin: 0 auto 30px; color: #beb4cd; line-height: 1.65; }
+.rs-404__copy > div { display: flex; justify-content: center; gap: 10px; flex-wrap: wrap; }
+.rs-404__fighter { height: 330px; display: flex; align-items: flex-end; justify-content: center; }
+.rs-404__fighter img { max-width: 100%; max-height: 100%; image-rendering: pixelated; filter: drop-shadow(0 16px 16px rgba(0,0,0,.78)); }
+.rs-404__fighter.b { transform: scaleX(-1); }
+@media (max-width: 700px) {
+  .rs-404 { min-height: 620px; grid-template-columns: 1fr 1fr; }
+  .rs-404__copy { grid-column: 1 / -1; grid-row: 1; padding: 60px 4px 10px; }
+  .rs-404__fighter { height: 220px; }
 }
 
 /* docs / bot page */
@@ -680,7 +782,7 @@ button.regen:disabled { opacity: 0.4; cursor: not-allowed; }
 .rs-fchip__art { width: 100%; height: 112px; border-radius: 8px; overflow: hidden; display: flex; align-items: flex-end; justify-content: center;
   background: radial-gradient(120% 90% at 50% 10%, color-mix(in srgb, var(--fc, #6fe0f0) 24%, #160f22) 0%, #130d1f 72%); border: 1px solid #2a2138; }
 .rs-fchip__art img { max-height: 96%; max-width: 90%; image-rendering: pixelated; filter: drop-shadow(0 4px 6px rgba(0,0,0,.5)); }
-.rs-fchip__name { margin-top: 8px; color: var(--fc, var(--gold)); font-weight: 800; letter-spacing: 1px; font-size: 15px; }
+.rs-fchip__name { margin-top: 8px; color: color-mix(in srgb, var(--fc, var(--gold)) 55%, white); font-weight: 800; letter-spacing: 1px; font-size: 15px; }
 .rs-fchip__tag { color: var(--dim); font-size: 10px; text-transform: uppercase; letter-spacing: .08em; text-align: center; margin-top: 2px; }
 
 .select-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(216px, 1fr)); gap: 18px; margin: 30px 0 44px; }
@@ -698,7 +800,7 @@ button.regen:disabled { opacity: 0.4; cursor: not-allowed; }
 .fcard__wr { position: absolute; top: 10px; left: 12px; z-index: 2; font-size: 10px; color: var(--text); background: rgba(11,8,18,.72);
   border: 1px solid var(--edge); border-radius: 999px; padding: 2px 8px; letter-spacing: .05em; }
 .fcard__foot { padding: 14px 16px 16px; }
-.fcard__name { color: var(--fc, var(--gold)); font-size: 25px; font-weight: 800; letter-spacing: 1px; text-shadow: 2px 2px 0 rgba(0,0,0,.45); }
+.fcard__name { color: color-mix(in srgb, var(--fc, var(--gold)) 55%, white); font-size: 25px; font-weight: 800; letter-spacing: 1px; text-shadow: 2px 2px 0 rgba(0,0,0,.45); }
 .fcard__arch { color: var(--text); font-size: 11px; text-transform: uppercase; letter-spacing: .12em; margin-top: 3px; }
 .fcard__tag { color: var(--dim); font-size: 12px; margin-top: 6px; font-style: italic; }
 
@@ -775,7 +877,7 @@ button.regen:disabled { opacity: 0.4; cursor: not-allowed; }
 .rs-lounge-side p { margin: 0 0 16px; color: #cfc7dd; line-height: 1.65; font-size: 13.5px; }
 .rs-lounge-side__list { list-style: none; margin: 0 0 auto; padding: 0; display: flex; flex-direction: column; gap: 11px; }
 .rs-lounge-side__list li { display: flex; align-items: center; gap: 11px; color: var(--text); font-size: 13px; }
-.rs-lounge-side__list li span { color: var(--cyan); font-size: 15px; width: 18px; text-align: center; }
+.rs-lounge-side__list li::before { content: ''; flex: 0 0 auto; width: 7px; height: 7px; background: var(--cyan); box-shadow: 2px 2px 0 rgba(245,217,74,.48); }
 .rs-lounge-side__list li em { color: var(--dim); font-style: normal; }
 .rs-cmd.sm { margin-top: 18px; padding: 11px 14px; }
 .rs-cmd.sm code { font-size: 13px; }

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -2,6 +2,7 @@ import './globals.css';
 import type { ReactNode } from 'react';
 import type { Metadata, Viewport } from 'next';
 import { GoogleAnalytics } from '@next/third-parties/google';
+import { DEFAULT_SOCIAL_IMAGE, DEFAULT_SOCIAL_IMAGE_ALT } from '@/lib/metadata';
 
 const DESC = 'An arcade fighting game you play entirely over SSH — a live ranked ladder, watchable replays, character stats, hand-drawn pixel sprites and a bot API. No install. Just connect and fight.';
 const GOOGLE_ANALYTICS_ID = 'G-H6D2K44Q8T';
@@ -16,6 +17,20 @@ export const metadata: Metadata = {
   creator: 'Thomas Davis (@ajaxdavis)',
   publisher: 'Thomas Davis',
   category: 'games',
+  alternates: { canonical: '/' },
+  formatDetection: { address: false, email: false, telephone: false },
+  manifest: '/manifest.webmanifest',
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+      'max-video-preview': -1,
+    },
+  },
   openGraph: {
     type: 'website',
     siteName: 'SSH Fighter',
@@ -23,6 +38,13 @@ export const metadata: Metadata = {
     url: '/',
     title: 'SSH Fighter',
     description: DESC,
+    images: [{
+      url: DEFAULT_SOCIAL_IMAGE,
+      width: 1200,
+      height: 630,
+      alt: DEFAULT_SOCIAL_IMAGE_ALT,
+      type: 'image/png',
+    }],
   },
   twitter: {
     card: 'summary_large_image',
@@ -30,6 +52,7 @@ export const metadata: Metadata = {
     site: '@ajaxdavis',
     title: 'SSH Fighter',
     description: DESC,
+    images: [{ url: DEFAULT_SOCIAL_IMAGE, alt: DEFAULT_SOCIAL_IMAGE_ALT }],
   },
 };
 

--- a/web/app/leaderboard/page.tsx
+++ b/web/app/leaderboard/page.tsx
@@ -2,9 +2,21 @@ import Link from 'next/link';
 import { SiteNav, Footer, CharChip, PlayerTypeBadge } from '@/components/ui';
 import { topPlayers, onlineNow, summary } from '@/lib/ringside';
 import { winRate } from '@/lib/format';
+import { pageMetadata } from '@/lib/metadata';
 
 export const dynamic = 'force-dynamic';
-export const metadata = { title: 'Leaderboard', description: 'The ranked Elo ladder.' };
+
+export async function generateMetadata({ searchParams }: { searchParams: Promise<{ division?: string }> }) {
+  const { division } = await searchParams;
+  const open = division === 'open';
+  return pageMetadata({
+    title: open ? 'Open League leaderboard' : 'Human League leaderboard',
+    description: open
+      ? 'Ranked Elo standings for every SSH Fighter competitor, with automated players clearly marked.'
+      : 'Ranked Elo standings for human SSH Fighter players competing from their terminals.',
+    path: open ? '/leaderboard?division=open' : '/leaderboard',
+  });
+}
 
 export default async function LeaderboardPage({ searchParams }: { searchParams: Promise<{ division?: string }> }) {
   const { division } = await searchParams;

--- a/web/app/manifest.ts
+++ b/web/app/manifest.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from 'next';
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: 'SSH Fighter',
+    short_name: 'SSH Fighter',
+    description: 'An arcade fighting game played entirely over SSH.',
+    start_url: '/',
+    display: 'standalone',
+    background_color: '#0b0812',
+    theme_color: '#17131f',
+    categories: ['games', 'entertainment'],
+    icons: [{ src: '/icon.svg', sizes: 'any', type: 'image/svg+xml' }],
+  };
+}

--- a/web/app/matches/[id]/page.tsx
+++ b/web/app/matches/[id]/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { cache } from 'react';
 import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 import { SiteNav, Footer, CharChip, PlayerTypeBadge } from '@/components/ui';
@@ -8,9 +9,11 @@ import ReplayViewer from './ReplayViewer';
 
 export const dynamic = 'force-dynamic';
 
+const getCachedMatch = cache(getMatch);
+
 export async function generateMetadata({ params }: { params: Promise<{ id: string }> }): Promise<Metadata> {
   const { id } = await params;
-  const m = getMatch(id);
+  const m = getCachedMatch(id);
   if (!m) return { title: 'Match not found', robots: { index: false, follow: false } };
   const replay = hasReplay(id);
   const ranked = m.mode === 'versus';
@@ -53,7 +56,7 @@ function describe(ev: { type: string; data: Record<string, unknown> }, aName: st
 
 export default async function MatchPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const m = getMatch(id);
+  const m = getCachedMatch(id);
   if (!m) notFound();
   const players = getMatchPlayers(id);
   const a = players.find((p) => p.side === 'a');

--- a/web/app/matches/page.tsx
+++ b/web/app/matches/page.tsx
@@ -2,9 +2,14 @@ import Link from 'next/link';
 import { SiteNav, Footer, CharChip, PlayerTypeBadge } from '@/components/ui';
 import { recentMatches, matchCount, onlineNow, hasReplay } from '@/lib/ringside';
 import { timeAgo, frames } from '@/lib/format';
+import { pageMetadata } from '@/lib/metadata';
 
 export const dynamic = 'force-dynamic';
-export const metadata = { title: 'Matches', description: 'Every recorded match. Drill in for the box score and replay.' };
+export const metadata = pageMetadata({
+  title: 'Matches and replays',
+  description: 'Browse recorded SSH Fighter matches, ranked results, box scores, and full watchable replays.',
+  path: '/matches',
+});
 
 const PER = 40;
 

--- a/web/app/not-found.tsx
+++ b/web/app/not-found.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { Footer, SiteNav, Sprite } from '@/components/ui';
+
+export const metadata: Metadata = {
+  title: 'Round not found',
+  description: 'That SSH Fighter page could not be found. Return to the arcade or browse the latest matches.',
+  robots: { index: false, follow: true },
+};
+
+export default function NotFound() {
+  return (
+    <div className="rs">
+      <SiteNav />
+      <main className="rs-wrap">
+        <section className="rs-404">
+          <div className="rs-404__fighter a" aria-hidden="true"><Sprite char="BYU" pose="ko" /></div>
+          <div className="rs-404__copy">
+            <span>404 · RING OUT</span>
+            <h1>This round is over.</h1>
+            <p>The page moved, the match ended, or the route never entered the arena.</p>
+            <div>
+              <Link className="rs-btn" href="/">Return home</Link>
+              <Link className="rs-btn ghost" href="/matches">Watch replays</Link>
+            </div>
+          </div>
+          <div className="rs-404__fighter b" aria-hidden="true"><Sprite char="CHONG" pose="victory_1" /></div>
+        </section>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -7,13 +7,15 @@ import { charColor, rosterNames, rosterCards } from '@/lib/chars';
 import { timeAgo, frames, num } from '@/lib/format';
 import { LiveMatches } from './LiveMatches';
 import { HomeTheater } from './HomeTheater';
+import { pageMetadata } from '@/lib/metadata';
 
 export const dynamic = 'force-dynamic';
-export const metadata = {
-  title: { absolute: 'SSH Fighter — an arcade fighting game over SSH' },
+export const metadata = pageMetadata({
+  title: 'SSH Fighter — an arcade fighting game over SSH',
   description: 'An arcade fighting game you play entirely over SSH. Live ladder, replays, character stats, and a bot API.',
-  alternates: { canonical: '/' },
-};
+  path: '/',
+  absoluteTitle: true,
+});
 
 export default async function Home() {
   const s = summary();
@@ -41,6 +43,9 @@ export default async function Home() {
             <p className="rs-lede">An arcade fighting game that runs entirely over SSH — hand-drawn pixel sprites,
               ranked matches, replays and a bot API. No install, no download. Just connect and fight.</p>
             <p className="rs-byline">Created by <a href="https://twitter.com/ajaxdavis" target="_blank" rel="noreferrer">@ajaxdavis</a> · <a href="https://ajaxdavis.dev" target="_blank" rel="noreferrer">ajaxdavis.dev</a></p>
+            <div className="rs-signal-tags" role="list" aria-label="Game highlights">
+              <span role="listitem">No install</span><span role="listitem">{cards.length} fighters</span><span role="listitem">Ranked ladder</span>
+            </div>
             <div className="rs-cta">
               <div className="rs-cmd">
                 <span className="p">$</span>
@@ -55,6 +60,13 @@ export default async function Home() {
           </div>
           {(lastReplay || live.activeMatches > 0) ? (
             <div className="rs-hero__theater">
+              <div className="rs-hero__art rs-hero__fallback" aria-hidden>
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img className="rs-hero__scene" src="/api/stage/neon" alt="" />
+                <SpriteLoop char={heroL} poses={['idle_1', 'idle_2']} className="l" />
+                <span className="vs">VS</span>
+                <SpriteLoop char={heroR} poses={['idle_1', 'idle_2']} className="r" />
+              </div>
               <HomeTheater replayId={lastReplay?.id ?? null} replayTitle={replayTitle} />
             </div>
           ) : (
@@ -81,7 +93,7 @@ export default async function Home() {
 
         {/* roster showcase */}
         <section className="rs-section">
-          <div className="rs-section__head"><h2>◈ {cards.length} fighters</h2><Link href="/fighters">Meet them all →</Link></div>
+          <div className="rs-section__head"><h2>{cards.length} fighters</h2><Link href="/fighters">Meet them all →</Link></div>
           <div className="rs-ribbon">
             {cards.map((c) => (
               <Link key={c.name} href={`/fighters/${c.name.toLowerCase()}`} className="rs-fchip" style={{ ['--fc' as string]: c.color }}>
@@ -95,7 +107,7 @@ export default async function Home() {
 
         {/* live now */}
         <section className="rs-section">
-          <div className="rs-section__head"><h2>◉ Live now</h2><Link href="/matches">All matches →</Link></div>
+          <div className="rs-section__head"><h2>Live now</h2><Link href="/matches">All matches →</Link></div>
           <LiveMatches initial={live.matches} colors={Object.fromEntries(names.map((n) => [n, charColor(n)]))} />
         </section>
 
@@ -152,7 +164,7 @@ export default async function Home() {
         {/* bots callout */}
         <section className="rs-section">
           <div className="rs-callout">
-            <h3>⌁ Bring your own fighter — the bot API</h3>
+            <h3>Bring your own fighter — the bot API</h3>
             <p>Register over SSH, then let an agent enter the Open League. Bot identities are marked automatically;
               humans can choose a bot opponent in Quick Match or switch to human-only matchmaking.</p>
             <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>

--- a/web/app/players/[name]/page.tsx
+++ b/web/app/players/[name]/page.tsx
@@ -1,20 +1,33 @@
 import Link from 'next/link';
+import { cache } from 'react';
 import { notFound } from 'next/navigation';
 import { SiteNav, Footer, CharChip, Sprite, Sparkline, Bars, Ring, PlayerTypeBadge } from '@/components/ui';
 import { profile, onlineNow } from '@/lib/ringside';
 import { charColor } from '@/lib/chars';
 import { timeAgo, frames, winRate, num, ordinal } from '@/lib/format';
+import { pageMetadata } from '@/lib/metadata';
 
 export const dynamic = 'force-dynamic';
 
+const getCachedProfile = cache(profile);
+
 export async function generateMetadata({ params }: { params: Promise<{ name: string }> }) {
   const { name } = await params;
-  return { title: `${decodeURIComponent(name)} — SSH Fighter` };
+  const username = decodeURIComponent(name);
+  const data = getCachedProfile(username);
+  if (!data) return { title: 'Player not found', robots: { index: false, follow: false } };
+  const { player } = data;
+  const matches = player.wins + player.losses;
+  return pageMetadata({
+    title: `${player.username} — player profile`,
+    description: `${player.username}'s SSH Fighter profile: ${player.elo} Elo, ${player.wins} wins, ${player.losses} losses across ${matches} ranked matches.`,
+    path: `/players/${encodeURIComponent(player.username)}`,
+  });
 }
 
 export default async function PlayerPage({ params }: { params: Promise<{ name: string }> }) {
   const { name } = await params;
-  const p = profile(decodeURIComponent(name));
+  const p = getCachedProfile(decodeURIComponent(name));
   if (!p) notFound();
   const { player, totals, byChar, recent, eloHistory } = p;
   const wr = winRate(player.wins, player.wins + player.losses);

--- a/web/app/roster/page.tsx
+++ b/web/app/roster/page.tsx
@@ -4,10 +4,15 @@ import { rosterSummary } from '@/lib/fighters';
 import { SiteNav, Footer } from '@/components/ui';
 import { onlineNow } from '@/lib/ringside';
 import Gallery from '../Gallery';
+import { pageMetadata } from '@/lib/metadata';
 
 export const dynamic = 'force-dynamic';
 
-export const metadata = { title: 'Roster & Sprites' };
+export const metadata = pageMetadata({
+  title: 'Sprite gallery',
+  description: 'Browse the complete SSH Fighter roster and every hand-drawn pixel animation pose used by the live game.',
+  path: '/roster',
+});
 
 export default function RosterPage() {
   const available = new Set(listChars());

--- a/web/app/status/page.tsx
+++ b/web/app/status/page.tsx
@@ -2,9 +2,14 @@ import { SiteNav, Footer, Sparkline } from '@/components/ui';
 import { AutoRefresh } from '@/components/AutoRefresh';
 import { opsLatest, opsTotalSeries, workerBreakdown, onlineNow, summary } from '@/lib/ringside';
 import { num } from '@/lib/format';
+import { pageMetadata } from '@/lib/metadata';
 
 export const dynamic = 'force-dynamic';
-export const metadata = { title: 'Server status', description: 'Live concurrency, load and process metrics.' };
+export const metadata = pageMetadata({
+  title: 'Server status',
+  description: 'See live SSH Fighter player concurrency, active matches, matchmaking queues, uptime, and server load.',
+  path: '/status',
+});
 
 function uptime(s: number): string {
   if (!s) return '—';

--- a/web/app/tv/page.tsx
+++ b/web/app/tv/page.tsx
@@ -2,12 +2,14 @@ import { SiteNav } from '@/components/ui';
 import { recentMatches, hasReplay } from '@/lib/ringside';
 import { getLive } from '@/lib/live';
 import { TvChannel } from '../TvChannel';
+import { pageMetadata } from '@/lib/metadata';
 
 export const dynamic = 'force-dynamic';
-export const metadata = {
+export const metadata = pageMetadata({
   title: 'TV',
   description: 'A never-ending channel of live SSH Fighter matches and recent replays.',
-};
+  path: '/tv',
+});
 
 export default async function TvPage() {
   const live = await getLive();
@@ -21,7 +23,7 @@ export default async function TvPage() {
       <SiteNav active="/tv" online={live.online} />
       <main className="rs-wrap rs-tv-wrap">
         <div className="rs-ph rs-tv-ph">
-          <h1>◉ SSH Fighter TV</h1>
+          <h1>SSH Fighter TV</h1>
           <p>Always on. Live fights the moment they start, recent replays in between — no need to touch a thing.</p>
         </div>
         <TvChannel replayPool={pool} />

--- a/web/app/watch/[mid]/page.tsx
+++ b/web/app/watch/[mid]/page.tsx
@@ -1,9 +1,19 @@
 import { SiteNav, Footer } from '@/components/ui';
 import { onlineNow } from '@/lib/ringside';
 import LiveViewer from './LiveViewer';
+import { pageMetadata } from '@/lib/metadata';
 
 export const dynamic = 'force-dynamic';
-export const metadata = { title: 'Watch live — SSH Fighter', description: 'Spectate a match in real time.' };
+
+export async function generateMetadata({ params }: { params: Promise<{ mid: string }> }) {
+  const { mid } = await params;
+  return pageMetadata({
+    title: 'Watch a live match',
+    description: 'Spectate a live SSH Fighter match in real time, including every strike, projectile, and round.',
+    path: `/watch/${encodeURIComponent(mid)}`,
+    robots: { index: false, follow: true },
+  });
+}
 
 export default async function WatchPage({ params }: { params: Promise<{ mid: string }> }) {
   const { mid } = await params;

--- a/web/components/ui.tsx
+++ b/web/components/ui.tsx
@@ -9,8 +9,20 @@ const LINKS: [string, string][] = [
 export function SiteNav({ active, online }: { active?: string; online?: number }) {
   return (
     <nav className="rs-nav">
+      <div className="rs-nav__signal" aria-hidden="true">
+        <div>
+          <span>PUBLIC TERMINAL ARCADE</span>
+          <span>NO INSTALL</span>
+          <span>RANKED FIGHTS</span>
+          <span>LIVE REPLAYS</span>
+        </div>
+      </div>
       <div className="rs-nav__in">
-        <Link href="/" className="rs-brand"><b />SSH FIGHTER</Link>
+        <Link href="/" className="rs-brand">
+          <b />
+          <span>SSH FIGHTER</span>
+          <span className="rs-brand__fighter" aria-hidden="true"><Sprite char="BYU" pose="idle_1" /></span>
+        </Link>
         <div className="rs-navlinks">
           {LINKS.map(([href, label]) => (
             <Link key={href} href={href} data-active={active === href ? '1' : undefined}>{label}</Link>
@@ -28,8 +40,13 @@ export function Footer() {
   return (
     <footer className="rs-footer">
       <div className="rs-wrap">
+        <div className="rs-footer__arena" aria-hidden="true">
+          <span className="rs-footer__fighter a"><Sprite char="BYU" pose="idle_1" /></span>
+          <span className="rs-footer__challenge"><small>THE NEXT ROUND STARTS IN YOUR TERMINAL</small><strong>ssh sshfighter.com</strong></span>
+          <span className="rs-footer__fighter b"><Sprite char="MEN" pose="idle_1" /></span>
+        </div>
         <div className="row">
-          <span className="rs-brand" style={{ textShadow: 'none' }}><b />SSH FIGHTER</span>
+          <span className="rs-brand" style={{ textShadow: 'none' }}><b /><span>SSH FIGHTER</span></span>
           <Link href="/fighters">Fighters</Link>
           <Link href="/bots">Build a bot</Link>
           <Link href="/status">Server status</Link>

--- a/web/lib/metadata.ts
+++ b/web/lib/metadata.ts
@@ -1,0 +1,56 @@
+import type { Metadata } from 'next';
+
+export const SITE_NAME = 'SSH Fighter';
+export const SITE_ORIGIN = 'https://sshfighter.com';
+export const DEFAULT_SOCIAL_IMAGE = '/opengraph-image';
+export const DEFAULT_SOCIAL_IMAGE_ALT = 'SSH Fighter — an arcade fighting game played entirely over SSH';
+
+interface PageMetadataOptions {
+  title: string;
+  description: string;
+  path: string;
+  absoluteTitle?: boolean;
+  image?: string;
+  imageAlt?: string;
+  robots?: Metadata['robots'];
+}
+
+/**
+ * Keep every public page consistent across search results, Open Graph cards,
+ * X cards, and canonical URLs. Dynamic match pages can override the image.
+ */
+export function pageMetadata({
+  title,
+  description,
+  path,
+  absoluteTitle = false,
+  image = DEFAULT_SOCIAL_IMAGE,
+  imageAlt = DEFAULT_SOCIAL_IMAGE_ALT,
+  robots,
+}: PageMetadataOptions): Metadata {
+  const images = [{ url: image, width: 1200, height: 630, alt: imageAlt, type: 'image/png' }];
+
+  return {
+    title: absoluteTitle ? { absolute: title } : title,
+    description,
+    alternates: { canonical: path },
+    openGraph: {
+      type: 'website',
+      siteName: SITE_NAME,
+      locale: 'en_US',
+      url: path,
+      title,
+      description,
+      images,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      creator: '@ajaxdavis',
+      site: '@ajaxdavis',
+      title,
+      description,
+      images: [{ url: image, alt: imageAlt }],
+    },
+    robots,
+  };
+}


### PR DESCRIPTION
## Summary
- extend the terminal arcade identity through the shared navigation, page headers, stat and match surfaces, and a sprite arena footer
- add a resilient sprite-stage homepage fallback and a custom ring-out 404
- centralize canonical, Open Graph, X, robots, and image metadata for every public route, plus a web manifest
- improve responsive behavior, focus/browser surfaces, and character-name contrast

## Verification
- Next.js 16.3.1 production build and TypeScript pass across 25 routes
- route-by-route metadata audit passes for static, query-driven, and dynamic pages plus 404
- desktop and mobile browser verification completed on home, leaderboard, bot roster, and 404
- WCAG audit findings addressed; Impeccable detector reports only the intentional grid in the technical tissue diagram