### PR TITLE
Make TV match handoffs explicit and race-safe

### DIFF
--- a/src/cluster/coordinator.ts
+++ b/src/cluster/coordinator.ts
@@ -307,7 +307,7 @@ export class MatchCoordinator {
   /** Full per-frame render payload for one live match (web spectator), or null. */
   renderMatch(mid: string): object | null {
     const am = this.matches.get(mid);
-    return am ? liveRender(am.match, am.a.name, am.b.name, am.a.isBot, am.b.isBot) : null;
+    return am ? liveRender(mid, am.match, am.a.name, am.b.name, am.a.isBot, am.b.isBot) : null;
   }
 }
 

--- a/src/coordinator-test.ts
+++ b/src/coordinator-test.ts
@@ -32,6 +32,9 @@ check('both players paired across workers', !!startA && !!startB && coord.active
 check('roles + opponent handles correct', startA?.role === 'a' && startB?.role === 'b' && startA?.oppName === 'BOB' && startB?.oppName === 'ALICE',
   `A opp=${startA?.oppName} B opp=${startB?.oppName}`);
 const mid = startA!.mid;
+const livePayload = coord.renderMatch(mid) as { mid?: string; aChar?: string; bChar?: string } | null;
+check('live spectator payload is bound to its match and fighters',
+  livePayload?.mid === mid && livePayload.aChar === 'BYU' && livePayload.bChar === 'CHONG');
 
 // Tick through countdown into the fight.
 for (let i = 0; i < 100; i++) coord.tick();

--- a/src/telemetry/replay-sim.ts
+++ b/src/telemetry/replay-sim.ts
@@ -168,10 +168,10 @@ export function replayMatchAtFrame(matchId: string, targetFrame: number): Match 
 
 /** Render payload for a LIVE match (single current frame + the same meta the
  *  replay viewer uses), so spectating reuses the exact renderer. */
-export function liveRender(m: Match, aName: string, bName: string, aBot = false, bBot = false): object {
+export function liveRender(mid: string, m: Match, aName: string, bName: string, aBot = false, bBot = false): object {
   const aChar = m.a.name, bChar = m.b.name;
   return {
-    stage: m.stage, aChar, bChar, aName, bName, aBot, bBot,
+    mid, stage: m.stage, aChar, bChar, aName, bName, aBot, bBot,
     worldW: WORLD_W, worldH: WORLD_H, groundY: GROUND_Y, fighterH: 58, stageLeft: STAGE_LEFT, stageRight: STAGE_RIGHT,
     sprites: { a: charSpriteMeta(aChar), b: charSpriteMeta(bChar) },
     frame: buildFrame(m), over: m.phase === 'match-over',

--- a/web/app/HomeTheater.tsx
+++ b/web/app/HomeTheater.tsx
@@ -1,10 +1,10 @@
 'use client';
 import Link from 'next/link';
 import { useEffect, useRef, useState } from 'react';
-import { drawFrame, ensureImages, stageUrl, CW, CH, type Frame, type RenderMeta } from '@/lib/replay-render';
+import { drawFrame, ensureImages, sameRenderIdentity, stageUrl, CW, CH, type Frame, type RenderMeta } from '@/lib/replay-render';
 
 interface Track extends RenderMeta { fps: number; frames: Frame[] }
-interface Live extends RenderMeta { frame: Frame; over: boolean }
+interface Live extends RenderMeta { mid: string; frame: Frame; over: boolean }
 type Mode = 'loading' | 'replay' | 'live' | 'none';
 
 function lerp(p: Frame, c: Frame, k: number): Frame {
@@ -32,7 +32,7 @@ export function HomeTheater({ replayId, replayTitle }: { replayId: string | null
   const setStageAndImgs = (m: RenderMeta) => {
     metaRef.current = m;
     if (!stage.current || stage.current.dataset?.stage !== m.stage) {
-      const si = new Image(); si.onload = () => { stage.current = si; }; si.src = stageUrl(m.stage); si.dataset && (si.dataset.stage = m.stage);
+      const si = new Image(); si.onload = () => { if (metaRef.current?.stage === m.stage) stage.current = si; }; si.src = stageUrl(m.stage); si.dataset && (si.dataset.stage = m.stage);
       stage.current = si;
     }
     ensureImages(m, imgs.current);
@@ -86,11 +86,14 @@ export function HomeTheater({ replayId, replayTitle }: { replayId: string | null
         const r = await fetch(`/api/live/${encodeURIComponent(mid)}`, { cache: 'no-store' });
         if (r.ok) {
           const d = await r.json() as Live;
-          if (!metaRef.current || metaRef.current.stage !== d.stage) setStageAndImgs(d);
+          if (!alive || modeRef.current !== 'live' || liveMid.current !== mid || d.mid !== mid) {
+            setTimeout(poll, 90); return;
+          }
+          if (!sameRenderIdentity(metaRef.current, d)) setStageAndImgs(d);
           prev.current = cur.current ?? { f: d.frame, t: performance.now() };
           cur.current = { f: d.frame, t: performance.now() };
           if (d.over) { modeRef.current = 'replay'; liveMid.current = null; setMode('replay'); loadReplay(); return; }
-        } else if (r.status === 404) { modeRef.current = 'replay'; liveMid.current = null; setMode('replay'); loadReplay(); return; }
+        } else if (r.status === 404 && liveMid.current === mid) { modeRef.current = 'replay'; liveMid.current = null; setMode('replay'); loadReplay(); return; }
       } catch { /* transient */ }
       setTimeout(poll, 90);
     };

--- a/web/app/TvChannel.tsx
+++ b/web/app/TvChannel.tsx
@@ -1,10 +1,10 @@
 'use client';
 import Link from 'next/link';
 import { useEffect, useRef, useState } from 'react';
-import { drawFrame, ensureImages, stageUrl, CW, CH, type Frame, type RenderMeta } from '@/lib/replay-render';
+import { drawFrame, ensureImages, sameRenderIdentity, stageUrl, CW, CH, type Frame, type RenderMeta } from '@/lib/replay-render';
 
 interface Track extends RenderMeta { fps: number; frames: Frame[] }
-interface Live extends RenderMeta { frame: Frame; over: boolean }
+interface Live extends RenderMeta { mid: string; frame: Frame; over: boolean }
 
 function lerp(p: Frame, c: Frame, k: number): Frame {
   const L = (a: number, b: number) => a + (b - a) * k;
@@ -17,6 +17,7 @@ function lerp(p: Frame, c: Frame, k: number): Frame {
 export function TvChannel({ replayPool }: { replayPool: { id: string; title: string }[] }) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [cap, setCap] = useState<{ text: string; sub: string; href: string; live: boolean }>({ text: 'Tuning in…', sub: '', href: '/matches', live: false });
+  const [handoff, setHandoff] = useState<{ mid: string; title: string; sub: string } | null>(null);
 
   const metaRef = useRef<RenderMeta | null>(null);
   const imgs = useRef(new Map<string, HTMLImageElement>());
@@ -36,7 +37,7 @@ export function TvChannel({ replayPool }: { replayPool: { id: string; title: str
   const setStageAndImgs = (m: RenderMeta) => {
     metaRef.current = m;
     if (!stage.current || stage.current.dataset?.stage !== m.stage) {
-      const si = new Image(); si.onload = () => { stage.current = si; }; si.src = stageUrl(m.stage); if (si.dataset) si.dataset.stage = m.stage;
+      const si = new Image(); si.onload = () => { if (metaRef.current?.stage === m.stage) stage.current = si; }; si.src = stageUrl(m.stage); if (si.dataset) si.dataset.stage = m.stage;
       stage.current = si;
     }
     ensureImages(m, imgs.current);
@@ -45,6 +46,9 @@ export function TvChannel({ replayPool }: { replayPool: { id: string; title: str
   const startLive = (m: any) => {
     kind.current = 'live'; liveMid.current = m.mid; track.current = null;
     prev.current = null; cur.current = null; metaRef.current = null;
+    const nextHandoff = { mid: m.mid, title: `${m.a.name} vs ${m.b.name}`, sub: `${m.a.char} vs ${m.b.char} · ${m.stage}` };
+    setHandoff(nextHandoff);
+    setTimeout(() => setHandoff((current) => current?.mid === m.mid ? null : current), 1200);
     setCap({ text: `${m.a.name}${m.a.bot ? ' [BOT]' : ''} vs ${m.b.name}${m.b.bot ? ' [BOT]' : ''}`, sub: `${m.a.char} vs ${m.b.char} · ${m.stage}`, href: `/watch/${m.mid}`, live: true });
   };
   const startReplay = async (r: { id: string; title: string }) => {
@@ -103,15 +107,22 @@ export function TvChannel({ replayPool }: { replayPool: { id: string; title: str
     const poll = async () => {
       if (!alive) return;
       if (kind.current !== 'live' || !liveMid.current) { setTimeout(poll, 250); return; }
+      const requestedMid = liveMid.current;
       try {
-        const r = await fetch(`/api/live/${encodeURIComponent(liveMid.current)}`, { cache: 'no-store' });
+        const r = await fetch(`/api/live/${encodeURIComponent(requestedMid)}`, { cache: 'no-store' });
         if (r.ok) {
           const d = await r.json() as Live;
-          if (!metaRef.current || metaRef.current.stage !== d.stage) setStageAndImgs(d);
+          if (!alive || kind.current !== 'live' || liveMid.current !== requestedMid || d.mid !== requestedMid) {
+            setTimeout(poll, 90); return;
+          }
+          if (!sameRenderIdentity(metaRef.current, d)) setStageAndImgs(d);
           prev.current = cur.current ?? { f: d.frame, t: performance.now() };
           cur.current = { f: d.frame, t: performance.now() };
-          if (d.over) { setTimeout(() => advance(), 2200); await new Promise((r2) => setTimeout(r2, 2200)); }
-        } else if (r.status === 404) { advance(); }
+          if (d.over) {
+            await new Promise((resolve) => setTimeout(resolve, 2200));
+            if (alive && liveMid.current === requestedMid) await advance();
+          }
+        } else if (r.status === 404 && liveMid.current === requestedMid) { await advance(); }
       } catch { /* transient */ }
       setTimeout(poll, 90);
     };
@@ -147,6 +158,9 @@ export function TvChannel({ replayPool }: { replayPool: { id: string; title: str
       <div className="rs-tv__screen">
         <canvas ref={canvasRef} width={CW} height={CH} />
         <div className="rs-tv__scan" aria-hidden />
+        {handoff && <div className="rs-tv__handoff" aria-live="polite">
+          <span>NEW MATCH</span><strong>{handoff.title}</strong><small>{handoff.sub}</small>
+        </div>}
         <div className="rs-tv__cap">
           <span className={`rs-tv__badge${cap.live ? ' live' : ''}`}>{cap.live ? <><span className="rs-dot" /> LIVE</> : 'REPLAY'}</span>
           <span className="rs-tv__title">{cap.text}</span>

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1028,6 +1028,12 @@ button.regen:disabled { opacity: 0.4; cursor: not-allowed; }
 .rs-tv__screen canvas { width: 100%; height: 100%; display: block; image-rendering: pixelated; }
 .rs-tv__scan { position: absolute; inset: 0; pointer-events: none; z-index: 2;
   background: repeating-linear-gradient(0deg, transparent 0 3px, var(--scan) 3px 4px); }
+.rs-tv__handoff { position: absolute; inset: 0; z-index: 4; display: flex; flex-direction: column; align-items: center; justify-content: center;
+  gap: 10px; pointer-events: none; color: var(--text); background: rgba(11,8,18,.9); text-align: center; animation: tv-handoff 1.2s ease both; }
+.rs-tv__handoff span { color: var(--red); font-size: 11px; font-weight: 900; letter-spacing: .24em; }
+.rs-tv__handoff strong { color: var(--gold); font-size: clamp(18px,3vw,32px); letter-spacing: .03em; }
+.rs-tv__handoff small { color: var(--dim); font-size: 12px; letter-spacing: .08em; text-transform: uppercase; }
+@keyframes tv-handoff { 0%,72% { opacity: 1; } 100% { opacity: 0; } }
 .rs-tv__cap { position: absolute; left: 0; right: 0; bottom: 0; z-index: 3; display: flex; align-items: center; gap: 14px;
   padding: 16px 20px; background: linear-gradient(0deg, rgba(11,8,18,.95), rgba(11,8,18,.5) 62%, transparent); font-size: 14px; }
 .rs-tv__badge { display: inline-flex; align-items: center; gap: 6px; font-weight: 800; letter-spacing: 1.5px; color: var(--gold);

--- a/web/app/watch/[mid]/LiveViewer.tsx
+++ b/web/app/watch/[mid]/LiveViewer.tsx
@@ -2,9 +2,9 @@
 import Link from 'next/link';
 import { useEffect, useRef, useState } from 'react';
 import { PlayerTypeBadge } from '@/components/ui';
-import { drawFrame, ensureImages, stageUrl, CW, CH, type Frame, type RenderMeta } from '@/lib/replay-render';
+import { drawFrame, ensureImages, sameRenderIdentity, stageUrl, CW, CH, type Frame, type RenderMeta } from '@/lib/replay-render';
 
-interface LivePayload extends RenderMeta { frame: Frame; over: boolean }
+interface LivePayload extends RenderMeta { mid: string; frame: Frame; over: boolean }
 const POLL_MS = 90;
 
 function lerp(p: Frame, c: Frame, k: number): Frame {
@@ -36,7 +36,8 @@ export default function LiveViewer({ mid }: { mid: string }) {
         else if (r.ok) {
           misses = 0;
           const d = await r.json() as LivePayload;
-          if (!meta.current) {
+          if (!alive || d.mid !== mid) { setTimeout(poll, POLL_MS); return; }
+          if (!sameRenderIdentity(meta.current, d)) {
             meta.current = d;
             setNames({ a: d.aName, b: d.bName, aBot: !!d.aBot, bBot: !!d.bBot });
             const si = new Image(); si.onload = () => { stageImg.current = si; }; si.src = stageUrl(d.stage);

--- a/web/lib/replay-render.ts
+++ b/web/lib/replay-render.ts
@@ -19,6 +19,14 @@ export interface RenderMeta {
   sprites: { a: CharMeta; b: CharMeta };
 }
 
+/** True only when an existing canvas metadata binding still describes the
+ * incoming match. Stage alone is not an identity: simultaneous matches can use
+ * the same stage with different fighters, as the TV channel routinely does. */
+export function sameRenderIdentity(a: RenderMeta | null, b: RenderMeta): boolean {
+  return !!a && a.stage === b.stage && a.aChar === b.aChar && a.bChar === b.bChar
+    && a.aName === b.aName && a.bName === b.bName;
+}
+
 export const CW = 960, CH = 640;
 export const spriteUrl = (char: string, name: string, ver?: number) =>
   `/api/sprite/${encodeURIComponent(char)}/${name}${ver ? `?v=${ver}` : ''}`;
@@ -112,7 +120,7 @@ function drawHud(ctx: CanvasRenderingContext2D, meta: RenderMeta, f: Frame) {
   ctx.textAlign = 'left'; ctx.fillText(meta.aName, pad, barY + barH + 22);
   ctx.textAlign = 'right'; ctx.fillText(meta.bName, CW - pad, barY + barH + 22);
   ctx.textAlign = 'center'; ctx.fillStyle = '#9a8fb5'; ctx.font = '600 13px ui-monospace, monospace';
-  ctx.fillText(f.ph === 'fight' ? `ROUND ${f.rd + 1}` : f.ph.toUpperCase(), CW / 2, barY + 13);
+  ctx.fillText(f.ph === 'fight' ? `ROUND ${f.rd}` : f.ph.toUpperCase(), CW / 2, barY + 13);
   if (f.msg) {
     ctx.font = '800 40px ui-monospace, monospace';
     ctx.fillStyle = '#17131f'; ctx.fillText(f.msg, CW / 2 + 2, CH * 0.42 + 2);


### PR DESCRIPTION
## What happened

The reported FABLE-to-OMEGA switch was a TV channel splice, not an engine character mutation. Match `mmt40i2gi130` ended while concurrent match `mmt40i9yu131` was already in round 2 on the same canyon stage. The channel changed matches after its post-match delay, and the web HUD rendered the 1-based engine round as `rd + 1`, so the incoming fight appeared as round 3.

## Changes

- include the requested match ID in every live-render payload
- reject stale or mismatched live responses in all three web spectators
- refresh render metadata when fighter or player identity changes, even on the same stage
- guard asynchronous stage-image loads against stale metadata
- show a brief `NEW MATCH` slate on TV channel handoffs
- render the engine round number without the extra increment
- add a coordinator regression assertion binding a live payload to its match and fighters

## Verification

- `pnpm test`
- `pnpm test:e2e`
- `pnpm --dir web build`
- `git diff --check`